### PR TITLE
Autouzupełnianie pola tytułu rezerwacji

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -99,7 +99,7 @@ export function renderMain() {
         <form id="bookingForm" class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label class="text-sm">Tytuł wydarzenia</label>
-            <input name="title" required class="w-full border rounded-xl px-3 py-2" placeholder="np. Urodziny" />
+            <input name="title" required readonly class="w-full border rounded-xl px-3 py-2 bg-gray-50" placeholder="Uzupełni się automatycznie" />
           </div>
           <div>
             <label class="text-sm">Rodzaj</label>


### PR DESCRIPTION
## Summary
- make the booking title input read-only with a placeholder explaining it fills automatically
- build the booking title from the selected event type and a masked renter name
- keep the generated title synchronised when form fields change and before submission

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d05da9fd688322a7978e63126dec78