### PR TITLE
Add caretaker instruction modal and management page

### DIFF
--- a/editDescription.html
+++ b/editDescription.html
@@ -1,0 +1,278 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Instrukcje opiekunów — zarządzanie</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="p-4 bg-white shadow">
+    <div class="max-w-4xl mx-auto flex items-center justify-between gap-3 flex-wrap">
+      <div>
+        <h1 class="text-xl font-bold">Instrukcje opiekunów świetlic</h1>
+        <p class="text-sm text-gray-500">Zarządzaj tekstem wyświetlanym użytkownikom w aplikacji głównej.</p>
+      </div>
+      <a href="./index.html" class="text-sm text-blue-700 underline">← powrót do aplikacji</a>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto p-4 space-y-4">
+    <section class="bg-white rounded-2xl shadow-md p-5 space-y-4">
+      <div>
+        <label for="facilitySelect" class="block text-sm font-medium text-gray-700">Wybierz świetlicę</label>
+        <select id="facilitySelect" class="mt-1 w-full border rounded-xl px-3 py-2">
+          <option value="">— wybierz świetlicę —</option>
+        </select>
+      </div>
+      <div id="facilityMeta" class="text-sm text-gray-500 min-h-[1.5rem]"></div>
+      <div>
+        <label for="instructionsInput" class="block text-sm font-medium text-gray-700">Instrukcja od opiekuna</label>
+        <textarea
+          id="instructionsInput"
+          class="mt-1 w-full border rounded-xl px-3 py-2 h-64 resize-y"
+          placeholder="Opisz zasady korzystania ze świetlicy, np. sposób odbioru kluczy, wymagane dokumenty..."
+          disabled
+        ></textarea>
+      </div>
+      <div class="flex items-center gap-3 flex-wrap">
+        <button id="saveInstructions" type="button" class="px-4 py-2 rounded-xl bg-blue-600 text-white disabled:opacity-40 disabled:cursor-not-allowed" disabled>
+          💾 Zapisz instrukcję
+        </button>
+        <span id="saveMessage" class="text-sm text-gray-500"></span>
+      </div>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="./supabase-config.js"></script>
+  <script type="module">
+    import { INSTRUCTION_FIELDS, findInstructionInfo } from './js/utils/instructions.js';
+
+    const selectEl = document.getElementById('facilitySelect');
+    const textarea = document.getElementById('instructionsInput');
+    const saveBtn = document.getElementById('saveInstructions');
+    const messageEl = document.getElementById('saveMessage');
+    const metaEl = document.getElementById('facilityMeta');
+
+    const SUPABASE_URL = window.__SUPA?.SUPABASE_URL;
+    const SUPABASE_ANON_KEY = window.__SUPA?.SUPABASE_ANON_KEY;
+
+    if (!window.supabase || !window.supabase.createClient) {
+      alert('Nie wykryto Supabase SDK. Sprawdź dołączone skrypty.');
+    } else if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+      alert('Uzupełnij plik supabase-config.js poprawnymi danymi.');
+    } else {
+      const supa = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+      let facilities = [];
+      let selectedFacility = null;
+      let isSaving = false;
+
+      function showMessage(text, tone = 'info') {
+        if (!messageEl) {
+          return;
+        }
+        messageEl.textContent = text;
+        messageEl.classList.remove('text-red-600', 'text-emerald-600', 'text-gray-500');
+        if (!text) {
+          return;
+        }
+        if (tone === 'error') {
+          messageEl.classList.add('text-red-600');
+        } else if (tone === 'success') {
+          messageEl.classList.add('text-emerald-600');
+        } else {
+          messageEl.classList.add('text-gray-500');
+        }
+      }
+
+      function describeFacility(facility) {
+        if (!facility) {
+          return '';
+        }
+        const parts = [];
+        if (facility.postal_code || facility.city) {
+          parts.push([facility.postal_code, facility.city].filter(Boolean).join(' '));
+        }
+        if (facility.address_line1 || facility.address_line2) {
+          parts.push([facility.address_line1, facility.address_line2].filter(Boolean).join(', '));
+        }
+        return parts.filter(Boolean).join(' · ');
+      }
+
+      function updateMeta(facility) {
+        if (!metaEl) {
+          return;
+        }
+        const description = describeFacility(facility);
+        metaEl.textContent = description || '';
+      }
+
+      function updateForm() {
+        const info = findInstructionInfo(selectedFacility);
+        if (!selectedFacility) {
+          textarea.value = '';
+          textarea.disabled = true;
+          saveBtn.disabled = true;
+          updateMeta(null);
+          showMessage('Wybierz świetlicę, aby edytować instrukcję.', 'info');
+          return;
+        }
+        textarea.disabled = false;
+        textarea.value = info.text || '';
+        saveBtn.disabled = false;
+        updateMeta(selectedFacility);
+        showMessage('', 'info');
+      }
+
+      function getCandidateColumns(facility) {
+        const seen = new Set();
+        const list = [];
+        if (facility?.__instructionsColumn) {
+          seen.add(facility.__instructionsColumn);
+          list.push(facility.__instructionsColumn);
+        }
+        for (const column of INSTRUCTION_FIELDS) {
+          if (!seen.has(column)) {
+            seen.add(column);
+            list.push(column);
+          }
+        }
+        return list;
+      }
+
+      async function persistInstructions(newValue) {
+        if (!selectedFacility) {
+          return;
+        }
+        const facilityId = selectedFacility.id;
+        const candidates = getCandidateColumns(selectedFacility);
+        let savedColumn = null;
+        let blockingError = null;
+        for (const column of candidates) {
+          const payload = { [column]: newValue };
+          const { error } = await supa.from('facilities').update(payload).eq('id', facilityId);
+          if (!error) {
+            savedColumn = column;
+            break;
+          }
+          if (error.code && error.code !== '42703') {
+            blockingError = error;
+            break;
+          }
+          if (!error.code && error.message && !/column/i.test(error.message)) {
+            blockingError = error;
+            break;
+          }
+        }
+        if (!savedColumn) {
+          throw blockingError || new Error('Nie udało się zapisać instrukcji dla tej świetlicy.');
+        }
+        selectedFacility.__instructionsColumn = savedColumn;
+        selectedFacility[savedColumn] = newValue;
+      }
+
+      async function handleSave() {
+        if (!selectedFacility || isSaving) {
+          return;
+        }
+        isSaving = true;
+        const originalLabel = saveBtn.textContent;
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Zapisywanie...';
+        selectEl.disabled = true;
+        showMessage('Trwa zapisywanie...', 'info');
+        const normalized = textarea.value.replace(/\r\n/g, '\n');
+        try {
+          await persistInstructions(normalized);
+          showMessage('Instrukcja została zapisana.', 'success');
+        } catch (error) {
+          console.error(error);
+          showMessage(error?.message || 'Wystąpił błąd podczas zapisu.', 'error');
+        } finally {
+          isSaving = false;
+          saveBtn.disabled = false;
+          saveBtn.textContent = originalLabel;
+          selectEl.disabled = false;
+        }
+      }
+
+      function renderFacilities() {
+        const previousValue = selectEl.value;
+        selectEl.innerHTML = '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = '— wybierz świetlicę —';
+        selectEl.appendChild(placeholder);
+
+        const sorted = [...facilities].sort((a, b) => {
+          const left = (a.name || '').toLocaleLowerCase('pl');
+          const right = (b.name || '').toLocaleLowerCase('pl');
+          if (left < right) return -1;
+          if (left > right) return 1;
+          return 0;
+        });
+
+        for (const facility of sorted) {
+          const option = document.createElement('option');
+          option.value = String(facility.id);
+          option.textContent = facility.name || `ID ${facility.id}`;
+          selectEl.appendChild(option);
+        }
+
+        if (previousValue) {
+          selectEl.value = previousValue;
+        }
+      }
+
+      function applySelectionFromQuery() {
+        const params = new URLSearchParams(window.location.search);
+        const fromQuery = params.get('facility');
+        if (!fromQuery) {
+          return;
+        }
+        const match = facilities.find((item) => String(item.id) === String(fromQuery));
+        if (match) {
+          selectEl.value = String(match.id);
+          selectedFacility = match;
+        }
+      }
+
+      async function loadFacilities() {
+        showMessage('Ładowanie listy świetlic...', 'info');
+        const { data, error } = await supa.from('facilities').select('*').order('name');
+        if (error) {
+          console.error(error);
+          showMessage('Nie udało się pobrać listy świetlic.', 'error');
+          return;
+        }
+        facilities = data || [];
+        renderFacilities();
+        applySelectionFromQuery();
+        if (!selectedFacility && facilities.length) {
+          selectedFacility = facilities[0];
+          selectEl.value = String(selectedFacility.id);
+        }
+        updateForm();
+      }
+
+      selectEl.addEventListener('change', () => {
+        const value = selectEl.value;
+        selectedFacility = facilities.find((facility) => String(facility.id) === String(value)) || null;
+        updateForm();
+      });
+
+      saveBtn.addEventListener('click', handleSave);
+      textarea.addEventListener('keydown', (event) => {
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+          event.preventDefault();
+          void handleSave();
+        }
+      });
+
+      void loadFacilities();
+    }
+  </script>
+</body>
+</html>

--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -5,6 +5,7 @@ export function createFacilitiesModule({
   formatUtils,
   dayView,
   docGenerator,
+  instructionsModal,
   googleMapsKey,
 }) {
   const { $ } = domUtils;
@@ -130,6 +131,9 @@ export function createFacilitiesModule({
       return;
     }
     state.selectedFacility = facility;
+    if (instructionsModal?.updateContent) {
+      instructionsModal.updateContent(facility);
+    }
     const card = $('#facilityCard');
     const selectors = $('#selectors');
     const booking = $('#booking');

--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,7 @@ import { createDayView } from './calendar/dayView.js';
 import { createMonthModal } from './calendar/monthModal.js';
 import { createBookingForm } from './booking/form.js';
 import { createDocGenerator } from './documents/docGenerator.js';
+import { createInstructionsModal } from './ui/instructionsModal.js';
 
 const supabase = createSupabaseClient();
 
@@ -26,6 +27,7 @@ if (!supabase) {
 
   const dayView = createDayView({ state, supabase, domUtils, formatUtils });
   const docGenerator = createDocGenerator({ state, supabase, domUtils, formatUtils });
+  const instructionsModal = createInstructionsModal({ state, domUtils });
   const facilities = createFacilitiesModule({
     state,
     supabase,
@@ -33,6 +35,7 @@ if (!supabase) {
     formatUtils,
     dayView,
     docGenerator,
+    instructionsModal,
     googleMapsKey: GOOGLE_MAPS_API_KEY,
   });
   const monthModal = createMonthModal({
@@ -49,6 +52,7 @@ if (!supabase) {
     renderSidebar({ onSearch: facilities.renderFacilityList });
     renderMain();
     dayView.attachDayViewListeners();
+    instructionsModal.attachListeners();
     monthModal.attachMonthModalListeners();
     bookingForm.installListeners();
     await facilities.loadDictionaries();

--- a/js/ui/instructionsModal.js
+++ b/js/ui/instructionsModal.js
@@ -1,0 +1,143 @@
+import { getInstructionText } from '../utils/instructions.js';
+
+export function createInstructionsModal({ state, domUtils }) {
+  const { $ } = domUtils;
+  let listenersAttached = false;
+
+  function getModal() {
+    return $('#instructionsModal');
+  }
+
+  function getTrigger() {
+    return $('#openFacilityInstructions');
+  }
+
+  function getContent() {
+    return $('#instructionsContent');
+  }
+
+  function getEditLink() {
+    return $('#editInstructionsLink');
+  }
+
+  function closeModal() {
+    const modal = getModal();
+    if (modal) {
+      modal.classList.add('hidden');
+    }
+  }
+
+  function updateTriggerState(facility) {
+    const trigger = getTrigger();
+    if (!trigger) {
+      return;
+    }
+    if (facility) {
+      trigger.disabled = false;
+      trigger.setAttribute('aria-disabled', 'false');
+      const text = (getInstructionText(facility) || '').trim();
+      trigger.title = text
+        ? 'Zobacz instrukcję od opiekuna'
+        : 'Dodaj instrukcję od opiekuna';
+      trigger.dataset.hasInstructions = text ? '1' : '0';
+      if (text) {
+        trigger.classList.add('bg-blue-600', 'text-white');
+        trigger.classList.remove('bg-white', 'text-blue-600', 'border', 'border-blue-600');
+      } else {
+        trigger.classList.add('bg-white', 'text-blue-600', 'border', 'border-blue-600');
+        trigger.classList.remove('bg-blue-600', 'text-white');
+      }
+    } else {
+      trigger.disabled = true;
+      trigger.setAttribute('aria-disabled', 'true');
+      trigger.title = 'Wybierz świetlicę, aby zobaczyć instrukcję';
+      trigger.dataset.hasInstructions = '0';
+      trigger.classList.add('bg-blue-600', 'text-white');
+      trigger.classList.remove('bg-white', 'text-blue-600', 'border', 'border-blue-600');
+    }
+  }
+
+  function updateEditLink(facility) {
+    const editLink = getEditLink();
+    if (!editLink) {
+      return;
+    }
+    if (facility && facility.id !== undefined && facility.id !== null) {
+      editLink.href = `./editDescription.html?facility=${encodeURIComponent(facility.id)}`;
+      editLink.classList.remove('pointer-events-none', 'opacity-50');
+    } else {
+      editLink.href = './editDescription.html';
+      editLink.classList.add('pointer-events-none', 'opacity-50');
+    }
+  }
+
+  function updateContent(facility = state.selectedFacility) {
+    const content = getContent();
+    updateTriggerState(facility);
+    updateEditLink(facility);
+    if (!content) {
+      return;
+    }
+    if (!facility) {
+      content.textContent = 'Najpierw wybierz świetlicę z listy obok.';
+      content.classList.add('text-gray-500');
+      return;
+    }
+    const text = (getInstructionText(facility) || '').trim();
+    if (text) {
+      content.textContent = text;
+      content.classList.remove('text-gray-500');
+    } else {
+      content.textContent = 'Brak instrukcji dodanych przez opiekuna dla tej świetlicy.';
+      content.classList.add('text-gray-500');
+    }
+  }
+
+  function openModal() {
+    if (!state.selectedFacility) {
+      return;
+    }
+    const modal = getModal();
+    if (!modal) {
+      return;
+    }
+    updateContent(state.selectedFacility);
+    modal.classList.remove('hidden');
+  }
+
+  function attachListeners() {
+    if (listenersAttached) {
+      return;
+    }
+    listenersAttached = true;
+    updateContent(state.selectedFacility);
+    const trigger = getTrigger();
+    if (trigger) {
+      trigger.addEventListener('click', openModal);
+    }
+    const closeBtn = $('#closeInstructionsModal');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeModal);
+    }
+    const modal = getModal();
+    if (modal) {
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+          closeModal();
+        }
+      });
+    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !getModal()?.classList.contains('hidden')) {
+        closeModal();
+      }
+    });
+  }
+
+  return {
+    attachListeners,
+    closeModal,
+    openModal,
+    updateContent,
+  };
+}

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -60,6 +60,15 @@ export function renderMain() {
             <button id="nextDay" class="px-3 py-2 rounded-xl border">▶</button>
             <input id="dayPicker" type="date" class="border rounded-xl px-3 py-2"/>
             <button id="openMonthPreview" class="px-3 py-2 rounded-xl border">Podgląd miesiąca</button>
+            <button
+              id="openFacilityInstructions"
+              type="button"
+              class="w-9 h-9 inline-flex items-center justify-center rounded-full bg-blue-600 text-white font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-40 disabled:cursor-not-allowed"
+              title="Instrukcja od opiekuna"
+              disabled
+            >
+              i
+            </button>
           </div>
           <div class="flex items-center gap-3">
             <span class="text-sm">Tryb:</span>
@@ -166,6 +175,26 @@ export function renderMain() {
         </div>
         <div id="fcContainer" class="p-3">
           <div id="fullCalendar" class="fc fc-media-screen"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="instructionsModal" class="fixed inset-0 z-50 hidden">
+      <div class="absolute inset-0 bg-black/40"></div>
+      <div class="relative mx-auto my-10 w-[min(640px,92vw)] bg-white rounded-2xl shadow-2xl overflow-hidden">
+        <div class="flex items-center justify-between px-4 py-3 border-b">
+          <div class="font-semibold">Instrukcja od opiekuna</div>
+          <div class="flex items-center gap-2">
+            <a
+              id="editInstructionsLink"
+              href="./editDescription.html"
+              class="px-3 py-1 rounded border text-sm text-blue-700 hover:bg-blue-50"
+            >Edytuj</a>
+            <button id="closeInstructionsModal" class="px-3 py-1 border rounded text-sm">Zamknij</button>
+          </div>
+        </div>
+        <div class="p-4">
+          <div id="instructionsContent" class="text-sm leading-relaxed text-gray-700 whitespace-pre-line"></div>
         </div>
       </div>
     </div>

--- a/js/utils/instructions.js
+++ b/js/utils/instructions.js
@@ -1,0 +1,76 @@
+export const INSTRUCTION_FIELDS = [
+  'caretaker_instructions',
+  'caretaker_instruction',
+  'caretaker_notes',
+  'instructions',
+  'instructions_text',
+  'instructions_markdown',
+  'booking_instructions',
+  'guardian_instructions',
+  'guardian_notes',
+  'manager_instructions',
+  'facility_instructions',
+];
+
+function toText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value);
+}
+
+export function findInstructionInfo(facility) {
+  if (!facility || typeof facility !== 'object') {
+    return { field: null, text: '' };
+  }
+  if (facility.__instructionsColumn) {
+    const rememberedValue = toText(facility[facility.__instructionsColumn]);
+    if (rememberedValue.trim()) {
+      return {
+        field: facility.__instructionsColumn,
+        text: rememberedValue,
+      };
+    }
+  }
+  for (const field of INSTRUCTION_FIELDS) {
+    const value = facility[field];
+    if (typeof value === 'string') {
+      if (value.trim()) {
+        facility.__instructionsColumn = field;
+        return { field, text: value };
+      }
+    } else if (value !== null && value !== undefined) {
+      const coerced = toText(value);
+      if (coerced.trim()) {
+        facility.__instructionsColumn = field;
+        return { field, text: coerced };
+      }
+    }
+  }
+  return {
+    field: facility.__instructionsColumn || null,
+    text: facility.__instructionsColumn ? toText(facility[facility.__instructionsColumn]) : '',
+  };
+}
+
+export function getInstructionText(facility) {
+  return findInstructionInfo(facility).text;
+}
+
+export function rememberInstructionField(facility, field) {
+  if (!facility || !field) {
+    return;
+  }
+  facility.__instructionsColumn = field;
+}
+
+export function assignInstructionValue(facility, field, value) {
+  if (!facility) {
+    return;
+  }
+  const targetField = field || facility.__instructionsColumn;
+  if (targetField) {
+    facility[targetField] = value;
+    facility.__instructionsColumn = targetField;
+  }
+}


### PR DESCRIPTION
## Summary
- add a highlighted “i” trigger beside the month preview button that opens a caretaker instruction modal with an edit shortcut
- wire the modal into facility selection via a dedicated controller and utility helpers for resolving instruction fields
- introduce an `editDescription.html` management screen for updating caretaker instructions through Supabase

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0636c9cd483228d97a7128c94708e