### PR TITLE
Remove public title toggle and default to masked title

### DIFF
--- a/js/booking/form.js
+++ b/js/booking/form.js
@@ -121,7 +121,7 @@ export function createBookingForm({ state, supabase, domUtils, formatUtils, dayV
       renter_name: form.renter_name.value.trim(),
       renter_email: form.renter_email.value.trim(),
       notes: form.notes.value.trim() || null,
-      is_public: $('#is_public')?.checked ?? true,
+      is_public: true,
       status: 'pending',
     };
     const { data, error } = await supabase.from('bookings').insert(payload).select();

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -143,11 +143,6 @@ export function renderMain() {
             <textarea name="notes" class="w-full border rounded-xl px-3 py-2" rows="2"></textarea>
           </div>
 
-          <div class="flex items-center gap-2 md:col-span-2">
-            <input id="is_public" type="checkbox" checked class="w-4 h-4"/>
-            <label for="is_public" class="text-sm">Pokaż tytuł wydarzenia publicznie w kalendarzu</label>
-          </div>
-
           <div class="md:col-span-2 flex gap-2 items-center">
             <button class="px-4 py-2 rounded-xl bg-blue-600 text-white" type="submit">
               Złóż wstępną rezerwację


### PR DESCRIPTION
## Summary
- remove the public-title checkbox from the booking form after introducing automatic title masking
- always submit bookings with the public flag enabled so the masked title is shown in the calendar

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0703e7830832283e7c7e534465af7