### PR TITLE
Remove document generation link from booking form

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ten pakiet zawiera działające MVP:
 1. W Supabase wykonaj `schema.sql` (SQL Editor).
 2. W `index.html` podmień `SUPABASE_URL` oraz `SUPABASE_ANON_KEY`.
 3. Wgraj `index.html` do GitHub i włącz Pages.
-4. Wybierz świetlicę, utwórz rezerwację — po zapisie pojawi się link **„Generuj dokumenty”**.
+4. Wybierz świetlicę, utwórz rezerwację — po zapisie pojawi się sekcja generowania dokumentów.
 5. Wybierz szablon i drukuj (PDF z przeglądarki).
 
 ## Szablony dokumentów

--- a/js/booking/form.js
+++ b/js/booking/form.js
@@ -137,8 +137,6 @@ export function createBookingForm({ state, supabase, domUtils, formatUtils, dayV
     state.lastBooking = bookingRow;
     state.bookingsCache.clear();
     await dayView.renderDay();
-    const docsLink = $('#genDocsLink');
-    docsLink?.classList.remove('hidden');
     const cancelBtn = $('#cancelThisBooking');
     cancelBtn?.classList.remove('hidden');
     if (bookingRow) {
@@ -169,14 +167,6 @@ export function createBookingForm({ state, supabase, domUtils, formatUtils, dayV
       await dayView.renderDay();
     } else {
       alert('Nie znaleziono lub już anulowana.');
-    }
-  }
-
-  function handleDocsLinkClick(event) {
-    event.preventDefault();
-    const el = $('#docGen');
-    if (el) {
-      window.scrollTo({ top: el.offsetTop - 20, behavior: 'smooth' });
     }
   }
 
@@ -241,10 +231,6 @@ export function createBookingForm({ state, supabase, domUtils, formatUtils, dayV
       cancelBtn.addEventListener('click', () => {
         void handleCancelClick();
       });
-    }
-    const docsLink = $('#genDocsLink');
-    if (docsLink) {
-      docsLink.addEventListener('click', handleDocsLinkClick);
     }
   }
 

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -152,7 +152,6 @@ export function renderMain() {
             <button class="px-4 py-2 rounded-xl bg-blue-600 text-white" type="submit">
               Złóż wstępną rezerwację
             </button>
-            <a id="genDocsLink" href="#" class="no-print hidden text-blue-700 underline">Generuj dokumenty</a>
             <button id="cancelThisBooking" type="button" class="no-print hidden px-3 py-2 border rounded-xl">Anuluj tę rezerwację</button>
             <div id="formMsg" class="text-sm ml-2"></div>
           </div>


### PR DESCRIPTION
## Summary
- remove the obsolete "Generuj dokumenty" link from the booking form layout
- clean up the form logic that previously managed the link visibility and click handler
- update the quick start guide to reflect the new document generation flow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d073820388832282165ce1eec9c2cd