### PR TITLE
Add booking loading from shared links

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -44,7 +44,15 @@ if (!supabase) {
     renderDay: dayView.renderDay,
     setDayPickerFromCurrent: dayView.setDayPickerFromCurrent,
   });
-  const bookingForm = createBookingForm({ state, supabase, domUtils, formatUtils, dayView, docGenerator });
+  const bookingForm = createBookingForm({
+    state,
+    supabase,
+    domUtils,
+    formatUtils,
+    dayView,
+    docGenerator,
+    facilities,
+  });
 
   window.initMapsApi = facilities.initMapsApi;
 
@@ -57,7 +65,7 @@ if (!supabase) {
     bookingForm.installListeners();
     await facilities.loadDictionaries();
     await facilities.loadFacilities();
-    await bookingForm.tryCancelFromUrl();
+    await bookingForm.tryLoadBookingFromUrl();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- allow the booking form to fetch reservation details by token from the URL for reuse during cancellation and document generation
- reuse helpers to reveal post-booking actions, select the facility, and surface status messages when a booking is loaded
- wire application init to invoke the new loader once facilities and dictionaries are available

## Testing
- node --check js/booking/form.js
- node --check js/main.js

------
https://chatgpt.com/codex/tasks/task_e_68d074192fc88322aeae6235fd8d83dc