### PR TITLE
Remove gallery column limit lookup

### DIFF
--- a/js/state/appState.js
+++ b/js/state/appState.js
@@ -11,7 +11,6 @@ export const state = {
   mapsReady: false,
   galleryImages: [],
   galleryCurrentIndex: 0,
-  galleryColumnMeta: null,
   galleryFacilityName: '',
   docFormValues: {},
   docSelectedTemplate: null,


### PR DESCRIPTION
## Summary
- stop checking the Supabase information schema for the gallery column limit and avoid surfacing related errors in the UI
- simplify the gallery info banner to only mention whether links exist
- remove the unused gallery column metadata state entry

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d0f7d12d408322b70ef0547b4bda88