### PR TITLE
Add daily intro video overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <!-- Style własne -->
   <link rel="stylesheet" href="./styles.css">
 </head>
-<body class="bg-gray-50 text-gray-900">
+<body class="bg-gray-50 text-gray-900" data-intro-video-src="./assets/intro.mp4">
   <!-- Nagłówek -->
   <header class="p-4 bg-white shadow">
     <div class="max-w-6xl mx-auto flex items-center justify-between">

--- a/js/main.js
+++ b/js/main.js
@@ -17,6 +17,7 @@ import { createBookingForm } from './booking/form.js';
 import { createDocGenerator } from './documents/docGenerator.js';
 import { createInstructionsModal } from './ui/instructionsModal.js';
 import { createGalleryModal } from './ui/galleryModal.js';
+import { createIntroVideoModal } from './ui/introVideo.js';
 
 const supabase = createSupabaseClient();
 
@@ -30,6 +31,7 @@ if (!supabase) {
   const docGenerator = createDocGenerator({ state, supabase, domUtils, formatUtils });
   const instructionsModal = createInstructionsModal({ state, domUtils });
   const galleryModal = createGalleryModal({ state, domUtils, formatUtils });
+  const introVideoModal = createIntroVideoModal();
   const facilities = createFacilitiesModule({
     state,
     supabase,
@@ -52,6 +54,7 @@ if (!supabase) {
   window.initMapsApi = facilities.initMapsApi;
 
   async function init() {
+    introVideoModal.showIfNeeded();
     renderSidebar({ onSearch: facilities.renderFacilityList });
     renderMain();
     dayView.attachDayViewListeners();

--- a/js/ui/introVideo.js
+++ b/js/ui/introVideo.js
@@ -1,0 +1,217 @@
+const STORAGE_KEY = 'introVideoLastSeen';
+const DEFAULT_VIDEO_PATH = './assets/intro.mp4';
+
+const pad2 = (value) => String(value).padStart(2, '0');
+
+const getTodayKey = () => {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
+};
+
+const safeGetStorage = (key) => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn('Nie udało się odczytać informacji o intro wideo z localStorage.', error);
+    return null;
+  }
+};
+
+const safeSetStorage = (key, value) => {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn('Nie udało się zapisać informacji o intro wideo w localStorage.', error);
+  }
+};
+
+const resolveVideoSrc = (explicitSrc) => {
+  if (explicitSrc && explicitSrc.trim()) {
+    return explicitSrc.trim();
+  }
+
+  const dataSrc = document.body?.dataset?.introVideoSrc;
+  if (dataSrc && dataSrc.trim()) {
+    return dataSrc.trim();
+  }
+
+  return DEFAULT_VIDEO_PATH;
+};
+
+export function createIntroVideoModal(options = {}) {
+  const {
+    storageKey = STORAGE_KEY,
+    videoSrc: configuredVideoSrc,
+  } = options;
+
+  let overlay;
+  let dialog;
+  let frame;
+  let mainVideo;
+  let blurVideo;
+  let closeButton;
+
+  const isOverlayVisible = () => overlay && !overlay.classList.contains('hidden');
+
+  const hideOverlay = () => {
+    if (!overlay) {
+      return;
+    }
+
+    overlay.classList.add('hidden');
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('intro-video-open');
+
+    if (mainVideo) {
+      mainVideo.pause();
+      mainVideo.currentTime = 0;
+    }
+
+    if (blurVideo) {
+      blurVideo.pause();
+      blurVideo.currentTime = 0;
+    }
+  };
+
+  const ensureOverlay = (videoSrc) => {
+    if (overlay) {
+      if (mainVideo && mainVideo.getAttribute('src') !== videoSrc) {
+        mainVideo.setAttribute('src', videoSrc);
+        mainVideo.load();
+      }
+
+      if (blurVideo && blurVideo.getAttribute('src') !== videoSrc) {
+        blurVideo.setAttribute('src', videoSrc);
+        blurVideo.load();
+      }
+
+      return;
+    }
+
+    overlay = document.createElement('div');
+    overlay.id = 'intro-video-overlay';
+    overlay.className = 'intro-video-overlay hidden';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-hidden', 'true');
+
+    closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'intro-video-close';
+    closeButton.setAttribute('aria-label', 'Zamknij wideo powitalne');
+    closeButton.innerHTML = '&times;';
+    overlay.appendChild(closeButton);
+
+    dialog = document.createElement('div');
+    dialog.className = 'intro-video-dialog';
+    overlay.appendChild(dialog);
+
+    blurVideo = document.createElement('video');
+    blurVideo.className = 'intro-video-blur';
+    blurVideo.setAttribute('aria-hidden', 'true');
+    blurVideo.muted = true;
+    blurVideo.loop = true;
+    blurVideo.playsInline = true;
+    blurVideo.preload = 'auto';
+    blurVideo.setAttribute('src', videoSrc);
+    dialog.appendChild(blurVideo);
+
+    frame = document.createElement('div');
+    frame.className = 'intro-video-frame';
+    dialog.appendChild(frame);
+
+    mainVideo = document.createElement('video');
+    mainVideo.className = 'intro-video-main';
+    mainVideo.controls = true;
+    mainVideo.playsInline = true;
+    mainVideo.preload = 'auto';
+    mainVideo.autoplay = true;
+    mainVideo.muted = true;
+    mainVideo.setAttribute('src', videoSrc);
+    frame.appendChild(mainVideo);
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        hideOverlay();
+      }
+    });
+
+    dialog.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+
+    closeButton.addEventListener('click', hideOverlay);
+
+    mainVideo.addEventListener('ended', hideOverlay);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && isOverlayVisible()) {
+        hideOverlay();
+      }
+    });
+
+    document.body.appendChild(overlay);
+  };
+
+  const showOverlay = (videoSrc, dateKey) => {
+    ensureOverlay(videoSrc);
+
+    overlay.classList.remove('hidden');
+    overlay.removeAttribute('aria-hidden');
+    document.body.classList.add('intro-video-open');
+
+    requestAnimationFrame(() => {
+      if (closeButton) {
+        closeButton.focus({ preventScroll: true });
+      }
+    });
+
+    if (blurVideo) {
+      blurVideo.currentTime = 0;
+      const playBlurPromise = blurVideo.play();
+      if (playBlurPromise) {
+        playBlurPromise.catch(() => {
+          /* Ignorujemy błędy autoplay np. na urządzeniach mobilnych */
+        });
+      }
+    }
+
+    if (mainVideo) {
+      mainVideo.currentTime = 0;
+      const playPromise = mainVideo.play();
+      if (playPromise) {
+        playPromise.catch(() => {
+          /* Ignorujemy błędy autoplay wymagające interakcji użytkownika */
+        });
+      }
+    }
+
+    if (dateKey) {
+      safeSetStorage(storageKey, dateKey);
+    }
+  };
+
+  const showIfNeeded = ({ force = false } = {}) => {
+    const todayKey = getTodayKey();
+    const videoSrc = resolveVideoSrc(configuredVideoSrc);
+
+    if (!videoSrc) {
+      return;
+    }
+
+    if (!force) {
+      const lastSeen = safeGetStorage(storageKey);
+      if (lastSeen === todayKey) {
+        return;
+      }
+    }
+
+    showOverlay(videoSrc, todayKey);
+  };
+
+  return {
+    showIfNeeded,
+    hide: hideOverlay,
+    forceShow: () => showIfNeeded({ force: true }),
+  };
+}

--- a/styles.css
+++ b/styles.css
@@ -14,3 +14,104 @@ input[type="range"] {
 .doc .signs { display:flex; gap:40px; justify-content:space-between; margin-top:30px }
 .doc table.check { width:100%; border-collapse:collapse; margin-top:8px }
 .doc table.check td, .doc table.check th { border:1px solid #ccc; padding:6px }
+
+/* Intro video overlay */
+body.intro-video-open {
+  overflow: hidden;
+}
+
+.intro-video-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 9999;
+  backdrop-filter: blur(6px);
+}
+
+.intro-video-close {
+  position: absolute;
+  top: clamp(1rem, 2vh, 2.5rem);
+  right: clamp(1rem, 2vh, 2.5rem);
+  width: 44px;
+  height: 44px;
+  border-radius: 9999px;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  color: #fff;
+  background: rgba(15, 23, 42, 0.72);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.intro-video-close:hover,
+.intro-video-close:focus-visible {
+  background: rgba(15, 23, 42, 0.88);
+  outline: none;
+}
+
+.intro-video-dialog {
+  position: relative;
+  width: min(100%, 520px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+.intro-video-dialog > * {
+  position: relative;
+  z-index: 1;
+}
+
+.intro-video-blur {
+  display: none;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(48px);
+  transform: scale(1.1);
+  opacity: 0.65;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+.intro-video-frame {
+  width: min(100%, 420px);
+  aspect-ratio: 9 / 16;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.35);
+  background: #000;
+}
+
+.intro-video-main {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #000;
+}
+
+@media (min-width: 1024px) {
+  .intro-video-dialog {
+    width: min(90vw, 960px);
+    min-height: clamp(320px, 52vh, 640px);
+  }
+
+  .intro-video-blur {
+    display: block;
+  }
+
+  .intro-video-frame {
+    width: min(40vw, 440px);
+  }
+}


### PR DESCRIPTION
## Summary
- add an intro video modal that renders once per day per visitor using localStorage tracking
- style the modal for vertical mobile playback and a blurred desktop background with a configurable video source
- provide an assets placeholder directory and hook the page body to point at the intro video file

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1083f15c483228a8c08a0a5a45563