### PR TITLE
Add caretaker registration page and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ Ten pakiet zawiera działające MVP:
 ## Modyfikacje
 - Dodaj nowe szablony w `document_templates` (INSERT) lub stwórz prosty panel w UI.
 - Możesz dostosować CSS w sekcji `<style id="print-styles">` w oknie wydruku.
+
+## Rejestracja opiekuna
+- W nagłówku aplikacji dostępny jest link „Zarejestruj opiekuna”, który prowadzi do formularza `registerCaretaker.html`.
+- Formularz zapisuje dane do tabeli `caretakers` oraz przypisania w tabeli `facility_caretakers`.
+- Strukturę i polityki RLS dla nowych tabel zawiera skrypt `supabase/caretakers.sql` — uruchom go po wdrożeniu głównego schematu bazy.

--- a/index.html
+++ b/index.html
@@ -15,9 +15,19 @@
 <body class="bg-gray-50 text-gray-900">
   <!-- Nagłówek -->
   <header class="p-4 bg-white shadow">
-    <div class="max-w-6xl mx-auto flex items-center justify-between">
-      <h1 class="text-2xl font-bold">Świetlice gminne — rezerwacje</h1>
-      <div class="text-sm text-gray-500">🦉 SOWA System Online do Wsparcia Automatycznej rezerwacji świetlic</div>
+    <div class="max-w-6xl mx-auto flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <h1 class="text-2xl font-bold">Świetlice gminne — rezerwacje</h1>
+      </div>
+      <div class="flex items-center gap-3 flex-wrap text-sm">
+        <div class="text-gray-500">🦉 SOWA System Online do Wsparcia Automatycznej rezerwacji świetlic</div>
+        <a
+          href="./registerCaretaker.html"
+          class="inline-flex items-center gap-1 rounded-xl border border-blue-200 px-3 py-1 font-medium text-blue-700 hover:bg-blue-50"
+        >
+          Zarejestruj opiekuna
+        </a>
+      </div>
     </div>
   </header>
 

--- a/js/caretakers/register.js
+++ b/js/caretakers/register.js
@@ -1,0 +1,281 @@
+import { createSupabaseClient } from '../config/supabaseClient.js';
+import { $ } from '../utils/dom.js';
+import { escapeHtml } from '../utils/format.js';
+
+const supabase = createSupabaseClient();
+
+const form = $('#caretakerForm');
+const messageEl = $('#formMessage');
+const facilitySelect = $('#facilitySelect');
+const facilityLoadingOverlay = $('#facilityLoading');
+const facilityInfo = $('#facilitySelectionInfo');
+
+const state = {
+  facilities: [],
+  isSubmitting: false,
+};
+
+function setMessage(text, tone = 'info') {
+  if (!messageEl) {
+    return;
+  }
+  messageEl.textContent = text || '';
+  messageEl.classList.remove('text-red-600', 'text-emerald-600', 'text-gray-500');
+  if (!text) {
+    return;
+  }
+  if (tone === 'error') {
+    messageEl.classList.add('text-red-600');
+  } else if (tone === 'success') {
+    messageEl.classList.add('text-emerald-600');
+  } else {
+    messageEl.classList.add('text-gray-500');
+  }
+}
+
+function toggleFormDisabled(disabled) {
+  if (!form) {
+    return;
+  }
+  const elements = form.querySelectorAll('input, select, button');
+  elements.forEach((element) => {
+    if (element) {
+      element.disabled = disabled;
+    }
+  });
+}
+
+function setFacilityLoading(isLoading) {
+  if (facilityLoadingOverlay) {
+    facilityLoadingOverlay.classList.toggle('hidden', !isLoading);
+  }
+  if (facilitySelect) {
+    facilitySelect.toggleAttribute('disabled', isLoading);
+  }
+}
+
+function describeFacility(facility) {
+  if (!facility) {
+    return '';
+  }
+  const parts = [facility.name || ''];
+  const addressParts = [facility.postal_code, facility.city].filter(Boolean).join(' ');
+  if (addressParts) {
+    parts.push(addressParts);
+  }
+  return parts.filter(Boolean).join(' • ');
+}
+
+function renderFacilities() {
+  if (!facilitySelect) {
+    return;
+  }
+  if (!state.facilities.length) {
+    facilitySelect.innerHTML = '';
+    facilitySelect.setAttribute('disabled', 'true');
+    if (facilityInfo) {
+      facilityInfo.textContent = '';
+    }
+    return;
+  }
+  const options = state.facilities
+    .map((facility) => {
+      const label = describeFacility(facility);
+      const value = escapeHtml(String(facility.id));
+      const text = escapeHtml(label);
+      return `<option value="${value}">${text}</option>`;
+    })
+    .join('');
+  facilitySelect.innerHTML = options;
+  facilitySelect.removeAttribute('disabled');
+  updateFacilitySelectionInfo();
+}
+
+function updateFacilitySelectionInfo() {
+  if (!facilityInfo) {
+    return;
+  }
+  if (!facilitySelect || !state.facilities.length) {
+    facilityInfo.textContent = '';
+    return;
+  }
+  const selectedCount = facilitySelect.selectedOptions?.length || 0;
+  const total = state.facilities.length;
+  facilityInfo.textContent = selectedCount
+    ? `Wybrano ${selectedCount} z ${total}`
+    : `Dostępnych: ${total}`;
+}
+
+async function loadFacilities() {
+  if (!supabase || !facilitySelect) {
+    return;
+  }
+  setFacilityLoading(true);
+  const { data, error } = await supabase
+    .from('facilities')
+    .select('id, name, city, postal_code')
+    .order('name');
+  setFacilityLoading(false);
+  if (error) {
+    console.error('Nie udało się pobrać świetlic:', error);
+    setMessage('Nie udało się pobrać listy świetlic. Spróbuj ponownie później.', 'error');
+    return;
+  }
+  state.facilities = data || [];
+  if (!state.facilities.length) {
+    setMessage('Brak zdefiniowanych świetlic w bazie danych.', 'error');
+  }
+  renderFacilities();
+}
+
+async function hashPassword(password) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const buffer = await crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function collectSelectedFacilityIds() {
+  if (!facilitySelect) {
+    return [];
+  }
+  return Array.from(facilitySelect.selectedOptions || []).map((option) => {
+    const match = state.facilities.find((facility) => String(facility.id) === option.value);
+    return match ? match.id : option.value;
+  });
+}
+
+function sanitizePhone(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function sanitizeLogin(value) {
+  return value.trim().toLowerCase();
+}
+
+function sanitizeEmail(value) {
+  return value.trim().toLowerCase();
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (!form || !supabase || state.isSubmitting) {
+    return;
+  }
+  const formData = new FormData(form);
+  const firstName = String(formData.get('first_name') || '').trim();
+  const lastNameOrCompany = String(formData.get('last_name_or_company') || '').trim();
+  const phone = sanitizePhone(String(formData.get('phone') || ''));
+  const email = sanitizeEmail(String(formData.get('email') || ''));
+  const loginRaw = String(formData.get('login') || '');
+  const password = String(formData.get('password') || '');
+  const passwordConfirm = String(formData.get('passwordConfirm') || '');
+  const facilityIds = collectSelectedFacilityIds();
+
+  if (!firstName || !lastNameOrCompany || !phone || !email || !loginRaw || !password) {
+    setMessage('Uzupełnij wszystkie wymagane pola formularza.', 'error');
+    return;
+  }
+
+  if (password !== passwordConfirm) {
+    setMessage('Hasła muszą być identyczne.', 'error');
+    return;
+  }
+
+  if (!facilityIds.length) {
+    setMessage('Wybierz co najmniej jedną świetlicę.', 'error');
+    return;
+  }
+
+  state.isSubmitting = true;
+  toggleFormDisabled(true);
+  setMessage('Trwa rejestrowanie opiekuna...', 'info');
+
+  if (!window.crypto?.subtle) {
+    setMessage('Ta przeglądarka nie obsługuje bezpiecznego haszowania haseł.', 'error');
+    state.isSubmitting = false;
+    toggleFormDisabled(false);
+    return;
+  }
+
+  try {
+    const passwordHash = await hashPassword(password);
+    const login = sanitizeLogin(loginRaw);
+    const payload = {
+      first_name: firstName,
+      last_name_or_company: lastNameOrCompany,
+      phone,
+      email,
+      login,
+      password_hash: passwordHash,
+    };
+
+    const { data: caretaker, error: insertError } = await supabase
+      .from('caretakers')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        setMessage('Podany login lub e-mail są już zajęte.', 'error');
+      } else {
+        setMessage(insertError.message || 'Nie udało się utworzyć konta opiekuna.', 'error');
+      }
+      return;
+    }
+
+    if (!caretaker || !caretaker.id) {
+      setMessage('Nie udało się uzyskać identyfikatora nowego opiekuna.', 'error');
+      return;
+    }
+
+    const assignments = facilityIds.map((facilityId) => ({
+      facility_id: facilityId,
+      caretaker_id: caretaker.id,
+    }));
+    const { error: joinError } = await supabase
+      .from('facility_caretakers')
+      .insert(assignments);
+
+    if (joinError) {
+      await supabase.from('caretakers').delete().eq('id', caretaker.id);
+      console.error('Błąd łączenia opiekuna ze świetlicami:', joinError);
+      setMessage('Nie udało się przypisać opiekuna do świetlic. Spróbuj ponownie.', 'error');
+      return;
+    }
+
+    form.reset();
+    updateFacilitySelectionInfo();
+    setMessage('Opiekun został zarejestrowany i przypisany do wybranych świetlic.', 'success');
+  } catch (error) {
+    console.error('Błąd rejestracji opiekuna:', error);
+    setMessage('Wystąpił nieoczekiwany błąd podczas rejestracji.', 'error');
+  } finally {
+    state.isSubmitting = false;
+    toggleFormDisabled(false);
+  }
+}
+
+if (!supabase) {
+  setMessage('Brak konfiguracji Supabase. Uzupełnij plik supabase-config.js.', 'error');
+  if (form) {
+    toggleFormDisabled(true);
+  }
+} else {
+  if (facilitySelect) {
+    facilitySelect.addEventListener('change', updateFacilitySelectionInfo);
+    facilitySelect.addEventListener('input', updateFacilitySelectionInfo);
+  }
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      void handleSubmit(event);
+    });
+  }
+  void loadFacilities();
+}

--- a/registerCaretaker.html
+++ b/registerCaretaker.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Rejestracja opiekuna świetlicy</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="p-4 bg-white shadow">
+    <div class="max-w-4xl mx-auto flex items-center justify-between gap-3 flex-wrap">
+      <div>
+        <h1 class="text-xl font-bold">Rejestracja opiekuna świetlicy</h1>
+        <p class="text-sm text-gray-500">Utwórz konto opiekuna i przypisz je do świetlic.</p>
+      </div>
+      <a href="./index.html" class="text-sm text-blue-700 underline">← powrót do aplikacji</a>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto p-4 space-y-4">
+    <section class="bg-white rounded-2xl shadow-md p-5 space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-lg font-semibold">Dane opiekuna</h2>
+        <p class="text-sm text-gray-600">
+          Wypełnij formularz, aby umożliwić wysyłkę powiadomień oraz logowanie opiekuna do panelu.
+        </p>
+      </div>
+      <form id="caretakerForm" class="space-y-5">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label for="firstName" class="block text-sm font-medium text-gray-700">Imię</label>
+            <input
+              id="firstName"
+              name="first_name"
+              type="text"
+              required
+              autocomplete="given-name"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+          <div>
+            <label for="lastName" class="block text-sm font-medium text-gray-700">Nazwisko lub nazwa</label>
+            <input
+              id="lastName"
+              name="last_name_or_company"
+              type="text"
+              required
+              autocomplete="family-name"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+          <div>
+            <label for="phone" class="block text-sm font-medium text-gray-700">Telefon</label>
+            <input
+              id="phone"
+              name="phone"
+              type="tel"
+              required
+              autocomplete="tel"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+          <div>
+            <label for="email" class="block text-sm font-medium text-gray-700">E-mail</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              autocomplete="email"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label for="login" class="block text-sm font-medium text-gray-700">Login</label>
+            <input
+              id="login"
+              name="login"
+              type="text"
+              required
+              minlength="3"
+              autocomplete="username"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+          <div>
+            <label for="password" class="block text-sm font-medium text-gray-700">Hasło</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minlength="8"
+              autocomplete="new-password"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+          <div>
+            <label for="passwordConfirm" class="block text-sm font-medium text-gray-700">Powtórz hasło</label>
+            <input
+              id="passwordConfirm"
+              name="passwordConfirm"
+              type="password"
+              required
+              minlength="8"
+              autocomplete="new-password"
+              class="mt-1 w-full border rounded-xl px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <label for="facilitySelect" class="block text-sm font-medium text-gray-700">
+              Przypisz opiekuna do świetlic
+            </label>
+            <span id="facilitySelectionInfo" class="text-xs text-gray-500"></span>
+          </div>
+          <p class="text-xs text-gray-500">Wybierz jedną lub więcej świetlic, za które opiekun będzie odpowiedzialny.</p>
+          <div id="facilitySelectWrap" class="relative">
+            <select
+              id="facilitySelect"
+              name="facility_ids"
+              class="w-full border rounded-xl px-3 py-2 h-48"
+              multiple
+              size="8"
+              aria-describedby="facilitySelectionInfo"
+            ></select>
+            <div id="facilityLoading" class="absolute inset-0 flex items-center justify-center bg-white/70 backdrop-blur-sm hidden">
+              <span class="text-sm text-gray-600">Ładowanie listy świetlic...</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-3 flex-wrap">
+          <button
+            id="submitCaretaker"
+            type="submit"
+            class="px-4 py-2 rounded-xl bg-blue-600 text-white font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Utwórz konto opiekuna
+          </button>
+          <span id="formMessage" class="text-sm text-gray-500"></span>
+        </div>
+      </form>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="./supabase-config.js"></script>
+  <script type="module" src="./js/caretakers/register.js"></script>
+</body>
+</html>

--- a/supabase/caretakers.sql
+++ b/supabase/caretakers.sql
@@ -1,0 +1,66 @@
+-- Struktura tabeli opiekunów oraz tabeli łączącej ich ze świetlicami.
+-- Uruchom w SQL Editorze Supabase po wcześniejszym wdrożeniu głównego schema.sql.
+
+create table if not exists public.caretakers (
+  id uuid primary key default gen_random_uuid(),
+  first_name text not null,
+  last_name_or_company text not null,
+  phone text not null,
+  email text not null,
+  login text not null,
+  password_hash text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists caretakers_login_unique
+  on public.caretakers (lower(login));
+
+create unique index if not exists caretakers_email_unique
+  on public.caretakers (lower(email));
+
+create or replace function public.set_caretaker_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists caretakers_set_updated_at on public.caretakers;
+create trigger caretakers_set_updated_at
+before update on public.caretakers
+for each row execute function public.set_caretaker_updated_at();
+
+create table if not exists public.facility_caretakers (
+  caretaker_id uuid not null references public.caretakers(id) on delete cascade,
+  -- Upewnij się, że typ kolumny odpowiada typowi public.facilities.id (standardowo uuid).
+  facility_id uuid not null references public.facilities(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (caretaker_id, facility_id)
+);
+
+create index if not exists facility_caretakers_facility_idx
+  on public.facility_caretakers (facility_id);
+
+create index if not exists facility_caretakers_caretaker_idx
+  on public.facility_caretakers (caretaker_id);
+
+alter table public.caretakers enable row level security;
+alter table public.facility_caretakers enable row level security;
+
+drop policy if exists "Allow anonymous caretakers insert" on public.caretakers;
+create policy "Allow anonymous caretakers insert"
+  on public.caretakers
+  for insert
+  to anon
+  with check (true);
+
+drop policy if exists "Allow anonymous facility caretakers insert" on public.facility_caretakers;
+create policy "Allow anonymous facility caretakers insert"
+  on public.facility_caretakers
+  for insert
+  to anon
+  with check (true);


### PR DESCRIPTION
## Summary
- add a caretaker registration page and form for capturing contact info, credentials, and facility assignments
- implement Supabase interactions to hash passwords, insert caretakers, and create facility links
- provide SQL definitions and RLS policies for caretaker tables, surface the link in the main header, and document the workflow

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0f9399a9083228f847f804284f3c5