### PR TITLE
feat: refresh booking layout styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,14 +32,14 @@
   </header>
 
   <!-- Layout -->
-  <main class="max-w-6xl mx-auto p-4 grid grid-cols-1 lg:grid-cols-3 gap-6">
+  <main class="main-shell mx-auto my-8 grid max-w-6xl grid-cols-1 gap-8 p-6 sm:p-8 lg:grid-cols-3">
     <!-- Lewa kolumna -->
-    <section class="lg:col-span-1 space-y-3">
+    <section class="lg:col-span-1">
       <div id="sidebar"></div>
     </section>
 
     <!-- Prawa kolumna -->
-    <section class="lg:col-span-2 space-y-4">
+    <section class="lg:col-span-2">
       <div id="main"></div>
     </section>
   </main>

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -1,5 +1,12 @@
 import { $ } from '../utils/dom.js';
 
+const CARD_BASE_CLASSES =
+  'rounded-3xl border border-white/40 bg-white/70 backdrop-blur shadow-xl shadow-blue-500/10';
+const HEADING_ACCENT_CLASSES =
+  'bg-gradient-to-r from-sky-400 via-blue-500 to-indigo-500 bg-clip-text text-transparent';
+const HEADING_DIVIDER_CLASSES =
+  'h-px flex-1 bg-gradient-to-r from-blue-500/40 via-blue-500/10 to-transparent';
+
 export function renderSidebar({ onSearch } = {}) {
   const root = $('#sidebar');
   if (!root) {
@@ -7,17 +14,43 @@ export function renderSidebar({ onSearch } = {}) {
     return;
   }
   root.innerHTML = `
-    <div class="bg-white rounded-xl shadow-md p-4">
-      <h2 class="font-semibold mb-3">Wyszukaj</h2>
-      <input id="q" class="w-full border rounded-xl px-3 py-2" placeholder="Szukaj ..." />
-    </div>
-    <div class="bg-white rounded-xl shadow-md p-4 mt-3">
-      <h2 class="font-semibold mb-3">Świetlice (<span id="count">0</span>)</h2>
-      <ul id="facilities" class="space-y-3"></ul>
-    </div>
-    <div id="mapCard" class="hidden bg-white rounded-xl shadow-md p-4 mt-3">
-      <h3 class="font-semibold mb-3">Mapa</h3>
-      <div id="map" style="width:100%;height:280px;border-radius:12px;"></div>
+    <div class="space-y-6">
+      <div class="${CARD_BASE_CLASSES} p-6">
+        <div class="flex items-center gap-3 pb-4">
+          <h2 class="text-lg font-semibold tracking-tight text-slate-900">
+            <span class="${HEADING_ACCENT_CLASSES}">Wyszukaj</span>
+          </h2>
+          <span class="${HEADING_DIVIDER_CLASSES}"></span>
+        </div>
+        <input
+          id="q"
+          class="w-full rounded-2xl border border-white/60 bg-white/60 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60"
+          placeholder="Szukaj ..."
+        />
+      </div>
+      <div class="${CARD_BASE_CLASSES} p-6">
+        <div class="flex items-center gap-3 pb-4">
+          <h2 class="text-lg font-semibold tracking-tight text-slate-900">
+            <span class="${HEADING_ACCENT_CLASSES}">Świetlice</span>
+            <span class="ml-2 text-sm font-medium text-slate-600">(<span id="count">0</span>)</span>
+          </h2>
+          <span class="${HEADING_DIVIDER_CLASSES}"></span>
+        </div>
+        <ul id="facilities" class="space-y-3"></ul>
+      </div>
+      <div id="mapCard" class="hidden ${CARD_BASE_CLASSES} p-6">
+        <div class="flex items-center gap-3 pb-4">
+          <h3 class="text-lg font-semibold tracking-tight text-slate-900">
+            <span class="${HEADING_ACCENT_CLASSES}">Mapa</span>
+          </h3>
+          <span class="${HEADING_DIVIDER_CLASSES}"></span>
+        </div>
+        <div
+          id="map"
+          class="rounded-2xl border border-white/40 shadow-inner shadow-blue-500/5"
+          style="width:100%;height:280px;"
+        ></div>
+      </div>
     </div>
   `;
   const search = $('#q');
@@ -33,154 +66,191 @@ export function renderMain() {
     return;
   }
   root.innerHTML = `
-    <div id="mainInner" class="space-y-6">
-      <div id="facilityCard" class="hidden bg-white rounded-2xl shadow-md overflow-hidden">
-        <div class="grid grid-cols-1 md:grid-cols-3 md:gap-4">
-          <div class="md:col-span-1">
-            <div id="facilityGallery" class="flex flex-col md:h-full">
-              <div class="relative">
-                <img id="facilityImgMain" class="w-full h-56 object-cover" alt="Zdjęcie świetlicy"/>
+    <div id="mainInner" class="relative z-10 space-y-6">
+      <div id="facilityCard" class="hidden ${CARD_BASE_CLASSES}">
+        <div class="flow-space space-y-6 p-6">
+          <div class="flex items-center gap-3">
+            <h2 class="text-lg font-semibold tracking-tight text-slate-900">
+              <span class="${HEADING_ACCENT_CLASSES}">Wybrana świetlica</span>
+            </h2>
+            <span class="${HEADING_DIVIDER_CLASSES}"></span>
+          </div>
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div class="md:col-span-1">
+              <div id="facilityGallery" class="flex flex-col gap-4 md:h-full">
+                <div class="relative overflow-hidden rounded-2xl bg-slate-900/5">
+                  <img id="facilityImgMain" class="h-56 w-full object-cover" alt="Zdjęcie świetlicy" />
+                  <button
+                    id="openGalleryBtn"
+                    type="button"
+                    class="absolute bottom-3 right-3 rounded-full bg-slate-900/80 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-white shadow-lg shadow-blue-500/30 backdrop-blur focus:outline-none focus:ring-2 focus:ring-sky-400/60"
+                    aria-haspopup="dialog"
+                  >
+                    Otwórz galerię
+                  </button>
+                </div>
+                <div id="facilityThumbs" class="hidden flex gap-2 overflow-x-auto pb-1"></div>
+                <div id="galleryColumnInfo" class="text-xs leading-snug text-slate-500">
+                  Wybierz świetlicę, aby zobaczyć zdjęcia.
+                </div>
+              </div>
+            </div>
+            <div class="space-y-4 md:col-span-2">
+              <div>
+                <h2 id="facilityName" class="text-2xl font-semibold tracking-tight text-slate-900"></h2>
+                <p id="facilityDesc" class="mt-1 text-sm text-slate-600"></p>
+              </div>
+              <div class="space-y-3 text-sm text-slate-700">
+                <div id="facilityAddr"></div>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span id="facilityCap" class="inline-flex items-center rounded-2xl bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 shadow-sm shadow-blue-500/10"></span>
+                  <span id="facilityPrices" class="inline-flex items-center rounded-2xl bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 shadow-sm shadow-blue-500/10"></span>
+                </div>
+                <div id="facilityAmenities" class="flex flex-wrap gap-2 text-xs text-slate-600"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="selectors" class="hidden ${CARD_BASE_CLASSES}">
+        <div class="flow-space space-y-6 p-6">
+          <div class="flex items-center gap-3">
+            <h3 class="text-lg font-semibold tracking-tight text-slate-900">
+              <span class="${HEADING_ACCENT_CLASSES}">Planowanie rezerwacji</span>
+            </h3>
+            <span class="${HEADING_DIVIDER_CLASSES}"></span>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 md:justify-between">
+            <div class="flex w-full flex-wrap items-center gap-2 md:w-auto">
+              <div class="flex w-full flex-wrap items-center gap-2 sm:flex-nowrap">
+                <div class="flex items-center gap-2">
+                  <button id="prevDay" class="rounded-2xl border border-white/60 bg-white/70 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-blue-500/10">◀</button>
+                  <button id="todayBtn" class="rounded-2xl border border-white/60 bg-white/70 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-blue-500/10">Dziś</button>
+                  <button id="nextDay" class="rounded-2xl border border-white/60 bg-white/70 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-blue-500/10">▶</button>
+                </div>
+                <input
+                  id="dayPicker"
+                  type="date"
+                  class="w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60 sm:w-auto"
+                />
+              </div>
+              <div class="flex w-full items-center gap-2 sm:w-auto sm:flex-nowrap">
+                <button id="openMonthPreview" class="w-full rounded-2xl border border-white/60 bg-white/70 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-blue-500/10 transition hover:border-blue-400/60 hover:text-blue-600 sm:w-auto">Podgląd miesiąca</button>
                 <button
-                  id="openGalleryBtn"
+                  id="openFacilityInstructions"
                   type="button"
-                  class="absolute bottom-2 right-2 px-3 py-1 rounded-full text-xs sm:text-sm bg-black/70 text-white shadow focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  aria-haspopup="dialog"
+                  class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 text-white font-semibold shadow-lg shadow-blue-500/30 focus:outline-none focus:ring-2 focus:ring-blue-300/60 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-40 sm:h-9 sm:w-9"
+                  title="Instrukcja od opiekuna"
+                  disabled
                 >
-                  Otwórz galerię
+                  i
                 </button>
               </div>
-              <div id="facilityThumbs" class="hidden mt-2 flex gap-2 overflow-x-auto pb-1"></div>
-              <div id="galleryColumnInfo" class="mt-2 text-xs text-gray-500 leading-snug">
-                Wybierz świetlicę, aby zobaczyć zdjęcia.
+            </div>
+            <div class="flex w-full flex-wrap items-center gap-3 text-sm text-slate-600 md:w-auto md:flex-nowrap">
+              <span class="text-sm font-medium text-slate-500">Tryb:</span>
+              <label class="inline-flex items-center gap-2 text-sm">
+                <input type="radio" name="mode" value="day" checked> Dni
+              </label>
+              <label class="inline-flex items-center gap-2 text-sm">
+                <input type="radio" name="mode" value="hour"> Godziny
+              </label>
+            </div>
+          </div>
+          <div id="hourSliderWrap" class="hidden rounded-2xl border border-white/50 bg-white/60 p-4">
+            <div class="grid grid-cols-1 items-center gap-3 md:grid-cols-3">
+              <div class="text-sm text-slate-600 md:col-span-1">Zakres godzin:</div>
+              <div class="flex items-center gap-3 md:col-span-2">
+                <div class="flex-1"><input id="hourStart" type="range" min="0" max="23" step="1"></div>
+                <div class="text-slate-500">—</div>
+                <div class="flex-1"><input id="hourEnd" type="range" min="0" max="23" step="1" value="23"></div>
+                <div class="whitespace-nowrap text-sm text-slate-600">
+                  <span id="hourStartLabel">12:00</span>–<span id="hourEndLabel">14:00</span>
+                </div>
               </div>
             </div>
           </div>
-          <div class="p-4 md:col-span-2">
-            <h2 id="facilityName" class="text-xl font-bold"></h2>
-            <p id="facilityDesc" class="text-sm text-gray-600 mt-1"></p>
-            <div class="mt-3 text-sm">
-              <div id="facilityAddr" class="text-gray-700"></div>
-              <div class="mt-1">
-                <span id="facilityCap" class="inline-block bg-gray-100 px-2 py-1 rounded-lg"></span>
-                <span id="facilityPrices" class="inline-block bg-gray-100 px-2 py-1 rounded-lg ml-2"></span>
-              </div>
-              <div id="facilityAmenities" class="mt-2 flex flex-wrap gap-2"></div>
-            </div>
-          </div>
+          <div id="dateLabel" class="text-lg font-semibold tracking-tight text-slate-800"></div>
         </div>
       </div>
 
-      <div id="selectors" class="hidden bg-white rounded-2xl shadow-md p-4">
-        <div class="flex flex-wrap items-center gap-3 md:justify-between">
-          <div class="flex w-full flex-wrap items-center gap-2 md:w-auto">
-            <div class="flex w-full flex-wrap items-center gap-2 sm:flex-nowrap">
-              <div class="flex items-center gap-2">
-                <button id="prevDay" class="px-3 py-2 rounded-xl border">◀</button>
-                <button id="todayBtn" class="px-3 py-2 rounded-xl border">Dziś</button>
-                <button id="nextDay" class="px-3 py-2 rounded-xl border">▶</button>
-              </div>
-              <input id="dayPicker" type="date" class="border rounded-xl px-3 py-2 w-full sm:w-auto"/>
-            </div>
-            <div class="flex w-full items-center gap-2 sm:w-auto sm:flex-nowrap">
-              <button id="openMonthPreview" class="w-full px-3 py-2 rounded-xl border sm:w-auto">Podgląd miesiąca</button>
-              <button
-                id="openFacilityInstructions"
-                type="button"
-                class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 sm:h-9 sm:w-9"
-                title="Instrukcja od opiekuna"
-                disabled
-              >
-                i
-              </button>
-            </div>
+      <div id="calendar" class="hidden ${CARD_BASE_CLASSES}">
+        <div class="flow-space space-y-6 p-6">
+          <div class="flex items-center gap-3">
+            <h3 class="text-lg font-semibold tracking-tight text-slate-900">
+              <span class="${HEADING_ACCENT_CLASSES}">Dostępność</span>
+            </h3>
+            <span class="${HEADING_DIVIDER_CLASSES}"></span>
           </div>
-          <div class="flex w-full flex-wrap items-center gap-3 text-sm md:w-auto md:flex-nowrap">
-            <span class="text-sm">Tryb:</span>
-            <label class="inline-flex items-center gap-2 text-sm">
-              <input type="radio" name="mode" value="day" checked> Dni
-            </label>
-            <label class="inline-flex items-center gap-2 text-sm">
-              <input type="radio" name="mode" value="hour"> Godziny
-            </label>
-          </div>
-        </div>
-        <div id="hourSliderWrap" class="hidden mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-3 items-center">
-            <div class="md:col-span-1 text-sm text-gray-700">Zakres godzin:</div>
-            <div class="md:col-span-2 flex items-center gap-3">
-              <div class="flex-1"><input id="hourStart" type="range" min="0" max="23" step="1"></div>
-              <div>—</div>
-              <div class="flex-1"><input id="hourEnd" type="range" min="0" max="23" step="1" value="23"></div>
-              <div class="whitespace-nowrap text-sm">
-                <span id="hourStartLabel">12:00</span>–<span id="hourEndLabel">14:00</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="text-lg font-semibold mt-3" id="dateLabel"></div>
-      </div>
-
-      <div id="calendar" class="hidden bg-white rounded-2xl shadow-md p-4">
-        <div id="hours" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"></div>
-        <p class="text-xs text-gray-500 mt-2">
-          🔴 Zajęte (potwierdzone) · 🟡 Wstępne (czeka na akceptację) · brak koloru = dostępne
-        </p>
-      </div>
-
-      <div id="booking" class="hidden bg-white rounded-2xl shadow p-4">
-        <h3 class="font-semibold mb-3">Nowa rezerwacja</h3>
-        <form id="bookingForm" class="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div>
-            <label class="text-sm">Rodzaj</label>
-            <select name="event_type_id" class="w-full border rounded-xl px-3 py-2"></select>
-          </div>
-          <div>
-            <label class="text-sm">Tytuł wydarzenia</label>
-            <input name="title" required readonly class="w-full border rounded-xl px-3 py-2 bg-gray-50" placeholder="Uzupełni się automatycznie" />
-          </div>
-
-          <div data-day-fields>
-            <label class="text-sm">Dzień rezerwacji</label>
-            <input name="day_only" type="date" class="w-full border rounded-xl px-3 py-2" />
-          </div>
-
-          <div data-hour-fields class="hidden">
-            <label class="text-sm">Początek (godzina)</label>
-            <input name="start_time" type="datetime-local" class="w-full border rounded-xl px-3 py-2" />
-          </div>
-          <div data-hour-fields class="hidden">
-            <label class="text-sm">Koniec (godzina)</label>
-            <input name="end_time" type="datetime-local" class="w-full border rounded-xl px-3 py-2" />
-          </div>
-
-          <div>
-            <label class="text-sm">Imię i nazwisko</label>
-            <input name="renter_name" required class="w-full border rounded-xl px-3 py-2" />
-          </div>
-          <div>
-            <label class="text-sm">E-mail</label>
-            <input name="renter_email" type="email" required class="w-full border rounded-xl px-3 py-2" />
-          </div>
-
-          <div class="md:col-span-2">
-            <label class="text-sm">Uwagi (opcjonalnie)</label>
-            <textarea name="notes" class="w-full border rounded-xl px-3 py-2" rows="2"></textarea>
-          </div>
-
-          <div class="md:col-span-2 flex gap-2 items-center">
-            <button class="px-4 py-2 rounded-xl bg-blue-600 text-white" type="submit">
-              Złóż wstępną rezerwację
-            </button>
-            <button id="cancelThisBooking" type="button" class="no-print hidden px-3 py-2 border rounded-xl">Anuluj tę rezerwację</button>
-            <div id="formMsg" class="text-sm ml-2"></div>
-          </div>
-
-          <p class="text-xs text-gray-500 md:col-span-2">
-            Wstępna rezerwacja trafia do opiekuna obiektu do akceptacji. Dostaniesz e-mail z decyzją.
+          <div id="hours" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"></div>
+          <p class="text-xs text-slate-500">
+            🔴 Zajęte (potwierdzone) · 🟡 Wstępne (czeka na akceptację) · brak koloru = dostępne
           </p>
-        </form>
+        </div>
+      </div>
 
-        <div id="docGen" class="mt-6"></div>
+      <div id="booking" class="hidden ${CARD_BASE_CLASSES}">
+        <div class="flow-space space-y-6 p-6">
+          <div class="flex items-center gap-3">
+            <h3 class="text-lg font-semibold tracking-tight text-slate-900">
+              <span class="${HEADING_ACCENT_CLASSES}">Nowa rezerwacja</span>
+            </h3>
+            <span class="${HEADING_DIVIDER_CLASSES}"></span>
+          </div>
+          <form id="bookingForm" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label class="text-sm font-medium text-slate-600">Rodzaj</label>
+              <select name="event_type_id" class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60"></select>
+            </div>
+            <div>
+              <label class="text-sm font-medium text-slate-600">Tytuł wydarzenia</label>
+              <input name="title" required readonly class="mt-1 w-full rounded-2xl border border-white/60 bg-white/50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" placeholder="Uzupełni się automatycznie" />
+            </div>
+
+            <div data-day-fields>
+              <label class="text-sm font-medium text-slate-600">Dzień rezerwacji</label>
+              <input name="day_only" type="date" class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" />
+            </div>
+
+            <div data-hour-fields class="hidden">
+              <label class="text-sm font-medium text-slate-600">Początek (godzina)</label>
+              <input name="start_time" type="datetime-local" class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" />
+            </div>
+            <div data-hour-fields class="hidden">
+              <label class="text-sm font-medium text-slate-600">Koniec (godzina)</label>
+              <input name="end_time" type="datetime-local" class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" />
+            </div>
+
+            <div>
+              <label class="text-sm font-medium text-slate-600">Imię i nazwisko</label>
+              <input name="renter_name" required class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" />
+            </div>
+            <div>
+              <label class="text-sm font-medium text-slate-600">E-mail</label>
+              <input name="renter_email" type="email" required class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" />
+            </div>
+
+            <div class="md:col-span-2">
+              <label class="text-sm font-medium text-slate-600">Uwagi (opcjonalnie)</label>
+              <textarea name="notes" class="mt-1 w-full rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-sm text-slate-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300/60" rows="2"></textarea>
+            </div>
+
+            <div class="md:col-span-2 flex flex-wrap items-center gap-3">
+              <button class="rounded-2xl bg-gradient-to-r from-sky-500 to-indigo-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-500/30 focus:outline-none focus:ring-2 focus:ring-blue-300/60" type="submit">
+                Złóż wstępną rezerwację
+              </button>
+              <button id="cancelThisBooking" type="button" class="no-print hidden rounded-2xl border border-white/60 bg-white/70 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm shadow-blue-500/10">Anuluj tę rezerwację</button>
+              <div id="formMsg" class="text-sm text-slate-600"></div>
+            </div>
+
+            <p class="text-xs text-slate-500 md:col-span-2">
+              Wstępna rezerwacja trafia do opiekuna obiektu do akceptacji. Dostaniesz e-mail z decyzją.
+            </p>
+          </form>
+
+          <div id="docGen" class="pt-2"></div>
+        </div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,72 @@
 /* Dodatkowe style poza Tailwind */
+
+.main-shell {
+  position: relative;
+  isolation: isolate;
+  border-radius: 40px;
+  background-color: #0f172a;
+  background-image:
+    radial-gradient(140% 140% at 50% 0%, rgba(56, 189, 248, 0.18), rgba(15, 23, 42, 0.92)),
+    radial-gradient(120% 120% at 80% 100%, rgba(99, 102, 241, 0.25), rgba(15, 23, 42, 0.95));
+  box-shadow: 0 45px 120px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+}
+
+.main-shell::before,
+.main-shell::after {
+  content: '';
+  position: absolute;
+  border-radius: 9999px;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  z-index: 0;
+}
+
+.main-shell::before {
+  top: -180px;
+  left: -140px;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.4), rgba(56, 189, 248, 0) 68%);
+}
+
+.main-shell::after {
+  bottom: -240px;
+  right: -180px;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.35), rgba(129, 140, 248, 0) 70%);
+}
+
+.main-shell > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 768px) {
+  .main-shell {
+    border-radius: 28px;
+  }
+
+  .main-shell::before {
+    width: 320px;
+    height: 320px;
+    top: -200px;
+    left: -180px;
+  }
+
+  .main-shell::after {
+    width: 360px;
+    height: 360px;
+    bottom: -280px;
+    right: -200px;
+  }
+}
+
+.flow-space > .hidden + * {
+  margin-top: 0 !important;
+}
 @media print {
   .no-print { display: none !important; }
 }


### PR DESCRIPTION
## Summary
- refresh sidebar and main cards with translucent glassmorphism styling, gradient headings, and roomier spacing
- wrap the booking layout in a radial gradient shell so cards float above a darker backdrop
- add utility styles for the gradient shell and flow spacing to keep hidden sections from adding gaps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d112e622e88322a542bd527d790c5a