### PR TITLE
Add caretaker login flow and secure session handling

### DIFF
--- a/caretakerLogin.html
+++ b/caretakerLogin.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Logowanie opiekuna świetlicy</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <header class="p-4 bg-white shadow">
+    <div class="max-w-3xl mx-auto flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h1 class="text-xl font-bold">Panel opiekuna świetlicy</h1>
+        <p class="text-sm text-gray-500">Zaloguj się, aby zarządzać instrukcjami i wyposażeniem swoich obiektów.</p>
+      </div>
+      <nav class="flex items-center gap-3 text-sm">
+        <a href="./index.html" class="text-blue-700 hover:underline">Aplikacja rezerwacyjna</a>
+        <a href="./registerCaretaker.html" class="text-blue-700 hover:underline">Rejestracja opiekuna</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto p-4 space-y-6">
+    <section class="bg-white rounded-2xl shadow-md p-6 space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-lg font-semibold">Logowanie</h2>
+        <p class="text-sm text-gray-500">Wprowadź swój login i hasło przekazane przez urząd gminy.</p>
+      </div>
+      <form id="caretakerLoginForm" class="space-y-5">
+        <div>
+          <label for="caretakerLogin" class="block text-sm font-medium text-gray-700">Login</label>
+          <input
+            id="caretakerLogin"
+            name="login"
+            type="text"
+            required
+            autocomplete="username"
+            class="mt-1 w-full border rounded-xl px-3 py-2"
+          />
+        </div>
+        <div>
+          <label for="caretakerPassword" class="block text-sm font-medium text-gray-700">Hasło</label>
+          <input
+            id="caretakerPassword"
+            name="password"
+            type="password"
+            required
+            autocomplete="current-password"
+            class="mt-1 w-full border rounded-xl px-3 py-2"
+          />
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <button
+            id="caretakerLoginSubmit"
+            type="submit"
+            class="px-4 py-2 rounded-xl bg-blue-600 text-white font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Zaloguj się
+          </button>
+          <a
+            id="caretakerPanelLink"
+            href="./editDescription.html"
+            class="hidden text-sm text-emerald-700 hover:underline"
+          >
+            Przejdź do panelu
+          </a>
+          <button
+            id="caretakerLogout"
+            type="button"
+            class="hidden text-sm text-red-600 hover:text-red-700"
+          >
+            Wyloguj
+          </button>
+          <span id="caretakerLoginMessage" class="text-sm text-gray-500"></span>
+        </div>
+      </form>
+    </section>
+
+    <section class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 space-y-3 text-sm text-gray-600">
+      <h2 class="text-base font-semibold text-gray-700">Potrzebujesz konta?</h2>
+      <p>Jeżeli nie posiadasz jeszcze danych logowania, poproś administratora systemu o utworzenie konta w panelu rejestracji opiekuna.</p>
+      <a href="./registerCaretaker.html" class="inline-flex items-center gap-2 text-blue-700 hover:underline">
+        <span>→ Otwórz formularz rejestracji</span>
+      </a>
+    </section>
+  </main>
+
+  <footer class="max-w-3xl mx-auto px-4 pb-6 text-xs text-gray-500">
+    🦉 SOWA — panel logowania opiekuna świetlicy
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="./supabase-config.js" defer></script>
+  <script type="module" src="./js/caretakers/login.js"></script>
+</body>
+</html>

--- a/checklistReport.html
+++ b/checklistReport.html
@@ -16,7 +16,7 @@
       </div>
       <nav class="flex items-center gap-3 text-sm">
         <a href="./index.html" class="text-blue-700 hover:underline">Aplikacja rezerwacyjna</a>
-        <a href="./editDescription.html" class="text-blue-700 hover:underline">Panel opiekuna</a>
+        <a href="./caretakerLogin.html" class="text-blue-700 hover:underline">Panel opiekuna</a>
       </nav>
     </div>
   </header>

--- a/editDescription.html
+++ b/editDescription.html
@@ -14,7 +14,10 @@
         <h1 class="text-xl font-bold">Instrukcje opiekunów świetlic</h1>
         <p class="text-sm text-gray-500">Zarządzaj tekstem wyświetlanym użytkownikom w aplikacji głównej.</p>
       </div>
-      <a href="./index.html" class="text-sm text-blue-700 underline">← powrót do aplikacji</a>
+      <nav class="flex items-center gap-3 text-sm">
+        <a href="./index.html" class="text-blue-700 hover:underline">Aplikacja rezerwacyjna</a>
+        <button id="caretakerLogout" type="button" class="text-red-600 hover:text-red-700">Wyloguj</button>
+      </nav>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
       <div class="flex items-center gap-3 flex-wrap text-sm">
         <div class="text-gray-500">🦉 SOWA System Online do Wsparcia Automatycznej rezerwacji świetlic</div>
         <a
+          href="./caretakerLogin.html"
+          class="inline-flex items-center gap-1 rounded-xl border border-indigo-200 px-3 py-1 font-medium text-indigo-700 hover:bg-indigo-50"
+        >
+          Panel opiekuna
+        </a>
+        <a
           href="./registerCaretaker.html"
           class="inline-flex items-center gap-1 rounded-xl border border-blue-200 px-3 py-1 font-medium text-blue-700 hover:bg-blue-50"
         >

--- a/js/admin/editDescriptionPage.js
+++ b/js/admin/editDescriptionPage.js
@@ -1,3 +1,4 @@
+import { clearCaretakerSession, requireCaretakerSession } from '../caretakers/session.js';
 import { INSTRUCTION_FIELDS, findInstructionInfo } from '../utils/instructions.js';
 
 const selectEl = document.getElementById('facilitySelect');
@@ -14,6 +15,7 @@ const checklistContainer = document.getElementById('checklistContainer');
 const checklistMessage = document.getElementById('checklistMessage');
 const addChecklistItemBtn = document.getElementById('addChecklistItem');
 const saveChecklistBtn = document.getElementById('saveChecklist');
+const logoutBtn = document.getElementById('caretakerLogout');
 
 const SUPABASE_URL = window.__SUPA?.SUPABASE_URL;
 const SUPABASE_ANON_KEY = window.__SUPA?.SUPABASE_ANON_KEY;
@@ -60,13 +62,30 @@ function escapeSelector(value) {
   return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
 }
 
-if (!window.supabase || !window.supabase.createClient) {
-  // eslint-disable-next-line no-alert
-  alert('Nie wykryto Supabase SDK. Sprawdź dołączone skrypty.');
-} else if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  // eslint-disable-next-line no-alert
-  alert('Uzupełnij plik supabase-config.js poprawnymi danymi.');
-} else {
+async function bootstrap() {
+  if (!window.supabase || !window.supabase.createClient) {
+    // eslint-disable-next-line no-alert
+    alert('Nie wykryto Supabase SDK. Sprawdź dołączone skrypty.');
+    return;
+  }
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    // eslint-disable-next-line no-alert
+    alert('Uzupełnij plik supabase-config.js poprawnymi danymi.');
+    return;
+  }
+
+  const session = await requireCaretakerSession({ redirectTo: './caretakerLogin.html' });
+  if (!session) {
+    return;
+  }
+
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', () => {
+      clearCaretakerSession();
+      window.location.replace('./caretakerLogin.html');
+    });
+  }
+
   const supa = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
   let facilities = [];
   let selectedFacility = null;
@@ -799,3 +818,5 @@ if (!window.supabase || !window.supabase.createClient) {
   void loadAmenitiesDictionary();
   void loadFacilities();
 }
+
+void bootstrap();

--- a/js/caretakers/login.js
+++ b/js/caretakers/login.js
@@ -1,0 +1,233 @@
+import { createSupabaseClient } from '../config/supabaseClient.js';
+import {
+  clearCaretakerSession,
+  getCaretakerDisplayName,
+  getCaretakerSession,
+  saveCaretakerSession,
+} from './session.js';
+import { $ } from '../utils/dom.js';
+
+const supabase = createSupabaseClient();
+
+const form = $('#caretakerLoginForm');
+const messageEl = $('#caretakerLoginMessage');
+const logoutBtn = $('#caretakerLogout');
+const panelLink = $('#caretakerPanelLink');
+const submitBtn = $('#caretakerLoginSubmit');
+const loginInput = $('#caretakerLogin');
+
+const state = {
+  isSubmitting: false,
+};
+
+function setMessage(text, tone = 'info') {
+  if (!messageEl) {
+    return;
+  }
+  messageEl.textContent = text || '';
+  messageEl.classList.remove('text-red-600', 'text-emerald-600', 'text-gray-500');
+  if (!text) {
+    return;
+  }
+  if (tone === 'error') {
+    messageEl.classList.add('text-red-600');
+  } else if (tone === 'success') {
+    messageEl.classList.add('text-emerald-600');
+  } else {
+    messageEl.classList.add('text-gray-500');
+  }
+}
+
+function toggleFormDisabled(disabled) {
+  if (!form) {
+    return;
+  }
+  const elements = form.querySelectorAll('input, button[type="submit"]');
+  elements.forEach((element) => {
+    element.disabled = disabled;
+  });
+}
+
+function sanitizeLogin(value) {
+  return value.trim().toLowerCase();
+}
+
+async function hashPassword(password) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const buffer = await window.crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return window.btoa(binary);
+}
+
+async function fetchCaretakerByLogin(login) {
+  if (!supabase) {
+    return { data: null, error: new Error('Brak klienta Supabase.') };
+  }
+  try {
+    const { data, error } = await supabase.rpc('caretaker_login_get', { p_login: login });
+    if (error) {
+      // Jeżeli funkcja RPC nie istnieje, spróbuj bezpośredniego zapytania (przydatne w środowisku developerskim).
+      if (error?.message?.toLowerCase().includes('function') || error?.code === 'PGRST301') {
+        const fallback = await supabase
+          .from('caretakers')
+          .select('id, login, password_hash, first_name, last_name_or_company')
+          .ilike('login', login)
+          .maybeSingle();
+        return { data: fallback.data, error: fallback.error };
+      }
+      return { data: null, error };
+    }
+    if (Array.isArray(data)) {
+      return { data: data[0] || null, error: null };
+    }
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error };
+  }
+}
+
+function updateUiForSession(session) {
+  if (panelLink) {
+    if (session) {
+      panelLink.classList.remove('hidden');
+    } else {
+      panelLink.classList.add('hidden');
+    }
+  }
+  if (logoutBtn) {
+    if (session) {
+      logoutBtn.classList.remove('hidden');
+    } else {
+      logoutBtn.classList.add('hidden');
+    }
+  }
+}
+
+function resolveRedirectTarget() {
+  const defaultTarget = './editDescription.html';
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const redirectParam = params.get('redirect');
+    if (!redirectParam) {
+      return defaultTarget;
+    }
+    const url = new URL(redirectParam, window.location.origin);
+    if (url.origin !== window.location.origin) {
+      return defaultTarget;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch (error) {
+    console.warn('Nie udało się zinterpretować adresu przekierowania:', error);
+    return defaultTarget;
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (!form || !supabase || state.isSubmitting) {
+    return;
+  }
+  const formData = new FormData(form);
+  const loginRaw = String(formData.get('login') || '');
+  const password = String(formData.get('password') || '');
+  if (!loginRaw.trim() || !password) {
+    setMessage('Podaj login i hasło.', 'error');
+    return;
+  }
+  if (!window.crypto?.subtle) {
+    setMessage('Ta przeglądarka nie obsługuje bezpiecznego logowania (WebCrypto).', 'error');
+    return;
+  }
+
+  state.isSubmitting = true;
+  toggleFormDisabled(true);
+  setMessage('Sprawdzanie danych logowania...', 'info');
+
+  try {
+    const login = sanitizeLogin(loginRaw);
+    const { data: caretaker, error } = await fetchCaretakerByLogin(login);
+    if (error) {
+      console.error('Błąd RPC logowania opiekuna:', error);
+      setMessage('Nie udało się zweryfikować danych logowania. Spróbuj ponownie później.', 'error');
+      return;
+    }
+    if (!caretaker || !caretaker.password_hash) {
+      setMessage('Nieprawidłowy login lub hasło.', 'error');
+      return;
+    }
+    const passwordHash = await hashPassword(password);
+    if (passwordHash !== caretaker.password_hash) {
+      setMessage('Nieprawidłowy login lub hasło.', 'error');
+      return;
+    }
+    const session = await saveCaretakerSession(caretaker);
+    updateUiForSession(session);
+    const displayName = getCaretakerDisplayName(session) || session.login;
+    setMessage(`Zalogowano jako ${displayName}. Przekierowanie...`, 'success');
+    const redirectTarget = resolveRedirectTarget();
+    window.setTimeout(() => {
+      window.location.href = redirectTarget;
+    }, 600);
+  } catch (error) {
+    console.error('Błąd logowania opiekuna:', error);
+    setMessage('Wystąpił nieoczekiwany błąd podczas logowania.', 'error');
+  } finally {
+    state.isSubmitting = false;
+    toggleFormDisabled(false);
+  }
+}
+
+function handleLogout() {
+  clearCaretakerSession();
+  updateUiForSession(null);
+  if (form) {
+    form.reset();
+  }
+  if (loginInput) {
+    loginInput.focus();
+  }
+  setMessage('Sesja została zakończona. Zaloguj się ponownie, aby kontynuować.', 'info');
+}
+
+async function init() {
+  if (!form) {
+    return;
+  }
+  if (!supabase) {
+    setMessage('Brak konfiguracji Supabase. Uzupełnij plik supabase-config.js.', 'error');
+    toggleFormDisabled(true);
+    return;
+  }
+  if (!window.crypto?.subtle) {
+    setMessage('Ta przeglądarka nie obsługuje bezpiecznego logowania (WebCrypto).', 'error');
+    toggleFormDisabled(true);
+    return;
+  }
+  const session = await getCaretakerSession();
+  if (session) {
+    updateUiForSession(session);
+    const displayName = getCaretakerDisplayName(session) || session.login;
+    setMessage(`Jesteś już zalogowany jako ${displayName}.`, 'info');
+  }
+}
+
+if (form) {
+  form.addEventListener('submit', (event) => {
+    void handleSubmit(event);
+  });
+}
+
+logoutBtn?.addEventListener('click', () => {
+  handleLogout();
+});
+
+if (!submitBtn) {
+  console.warn('Nie odnaleziono przycisku logowania opiekuna.');
+}
+
+void init();

--- a/js/caretakers/session.js
+++ b/js/caretakers/session.js
@@ -1,0 +1,217 @@
+import { SUPABASE_ANON_KEY } from '../config/supabaseClient.js';
+
+const CARETAKER_SESSION_STORAGE_KEY = 'caretaker.session.v1';
+
+function getBrowserStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    if (window.localStorage) {
+      return window.localStorage;
+    }
+  } catch (error) {
+    console.warn('Nie można uzyskać dostępu do localStorage:', error);
+  }
+  try {
+    if (window.sessionStorage) {
+      return window.sessionStorage;
+    }
+  } catch (error) {
+    console.warn('Nie można uzyskać dostępu do sessionStorage:', error);
+  }
+  return null;
+}
+
+function encodeBase64(text) {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return window.btoa(binary);
+}
+
+function decodeBase64(base64) {
+  const binary = window.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+
+function bufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return window.btoa(binary);
+}
+
+function safeStringEquals(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false;
+  }
+  let mismatch = a.length === b.length ? 0 : 1;
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0 && a.length === b.length;
+}
+
+function computeDisplayName(firstName, lastNameOrCompany, login) {
+  const parts = [];
+  if (firstName) {
+    parts.push(firstName);
+  }
+  if (lastNameOrCompany) {
+    parts.push(lastNameOrCompany);
+  }
+  if (parts.length) {
+    return parts.join(' ');
+  }
+  return login || '';
+}
+
+function buildPayload(caretaker, issuedAt = Date.now()) {
+  const caretakerId = caretaker?.caretakerId || caretaker?.id || null;
+  const login = caretaker?.login || '';
+  const firstName = caretaker?.first_name ?? caretaker?.firstName ?? null;
+  const lastNameOrCompany = caretaker?.last_name_or_company ?? caretaker?.lastNameOrCompany ?? null;
+  const displayName = caretaker?.displayName || computeDisplayName(firstName, lastNameOrCompany, login);
+  return {
+    version: 1,
+    caretakerId,
+    login,
+    firstName,
+    lastNameOrCompany,
+    displayName,
+    issuedAt,
+  };
+}
+
+function normalizePayload(payload) {
+  if (!payload) {
+    return null;
+  }
+  const caretakerId = payload.caretakerId ?? payload.id ?? null;
+  const login = payload.login || '';
+  const firstName = payload.firstName ?? payload.first_name ?? null;
+  const lastNameOrCompany = payload.lastNameOrCompany ?? payload.last_name_or_company ?? null;
+  const displayName = payload.displayName || computeDisplayName(firstName, lastNameOrCompany, login);
+  const issuedAt = payload.issuedAt ?? payload.iat ?? null;
+  return {
+    version: payload.version ?? 1,
+    caretakerId,
+    login,
+    firstName,
+    lastNameOrCompany,
+    displayName,
+    issuedAt,
+  };
+}
+
+function encodeToken(tokenObject) {
+  return encodeBase64(JSON.stringify(tokenObject));
+}
+
+function decodeToken(tokenString) {
+  const json = decodeBase64(tokenString);
+  return JSON.parse(json);
+}
+
+async function importSigningKey(secretOverride) {
+  if (!window.crypto?.subtle) {
+    throw new Error('WebCrypto API jest wymagane do podpisywania tokenów.');
+  }
+  const secretSource = secretOverride || SUPABASE_ANON_KEY || 'caretaker-session-fallback-secret';
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secretSource);
+  return window.crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+}
+
+async function signPayload(payload, secretOverride) {
+  const key = await importSigningKey(secretOverride);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(JSON.stringify(payload));
+  const signature = await window.crypto.subtle.sign('HMAC', key, data);
+  return bufferToBase64(signature);
+}
+
+async function verifySignature(payload, signature, secretOverride) {
+  const expected = await signPayload(payload, secretOverride);
+  return safeStringEquals(expected, signature);
+}
+
+export async function saveCaretakerSession(caretaker, { storage = getBrowserStorage(), secret } = {}) {
+  if (!storage) {
+    throw new Error('Brak dostępu do przeglądarkowego storage.');
+  }
+  const payload = buildPayload(caretaker);
+  const signature = await signPayload(payload, secret);
+  const tokenObject = { payload, signature };
+  const token = encodeToken(tokenObject);
+  storage.setItem(CARETAKER_SESSION_STORAGE_KEY, token);
+  return payload;
+}
+
+export function clearCaretakerSession({ storage = getBrowserStorage() } = {}) {
+  if (!storage) {
+    return;
+  }
+  storage.removeItem(CARETAKER_SESSION_STORAGE_KEY);
+}
+
+export async function getCaretakerSession({ storage = getBrowserStorage(), secret } = {}) {
+  if (!storage) {
+    return null;
+  }
+  const token = storage.getItem(CARETAKER_SESSION_STORAGE_KEY);
+  if (!token) {
+    return null;
+  }
+  try {
+    const decoded = decodeToken(token);
+    const payload = decoded?.payload;
+    const signature = decoded?.signature;
+    if (!payload || !signature) {
+      storage.removeItem(CARETAKER_SESSION_STORAGE_KEY);
+      return null;
+    }
+    const isValid = await verifySignature(payload, signature, secret);
+    if (!isValid) {
+      storage.removeItem(CARETAKER_SESSION_STORAGE_KEY);
+      return null;
+    }
+    return normalizePayload(payload);
+  } catch (error) {
+    console.warn('Nie udało się odczytać sesji opiekuna:', error);
+    storage.removeItem(CARETAKER_SESSION_STORAGE_KEY);
+    return null;
+  }
+}
+
+export async function requireCaretakerSession({ redirectTo, storage, secret } = {}) {
+  const session = await getCaretakerSession({ storage, secret });
+  if (!session && redirectTo) {
+    window.location.replace(redirectTo);
+  }
+  return session;
+}
+
+export function getCaretakerDisplayName(sessionLike) {
+  if (!sessionLike) {
+    return '';
+  }
+  if (sessionLike.displayName) {
+    return sessionLike.displayName;
+  }
+  return computeDisplayName(sessionLike.firstName, sessionLike.lastNameOrCompany, sessionLike.login);
+}
+
+export { CARETAKER_SESSION_STORAGE_KEY };

--- a/registerCaretaker.html
+++ b/registerCaretaker.html
@@ -14,7 +14,10 @@
         <h1 class="text-xl font-bold">Rejestracja opiekuna świetlicy</h1>
         <p class="text-sm text-gray-500">Utwórz konto opiekuna i przypisz je do świetlic.</p>
       </div>
-      <a href="./index.html" class="text-sm text-blue-700 underline">← powrót do aplikacji</a>
+      <nav class="flex items-center gap-3 text-sm">
+        <a href="./index.html" class="text-blue-700 hover:underline">Aplikacja rezerwacyjna</a>
+        <a href="./caretakerLogin.html" class="text-blue-700 hover:underline">Panel opiekuna</a>
+      </nav>
     </div>
   </header>
 

--- a/supabase/caretakers.sql
+++ b/supabase/caretakers.sql
@@ -64,3 +64,104 @@ create policy "Allow anonymous facility caretakers insert"
   for insert
   to anon
   with check (true);
+
+-- Funkcja pomocnicza do logowania opiekuna po loginie.
+drop function if exists public.caretaker_login_get(text);
+create or replace function public.caretaker_login_get(p_login text)
+returns table (
+  id uuid,
+  login text,
+  password_hash text,
+  first_name text,
+  last_name_or_company text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    c.id,
+    c.login,
+    c.password_hash,
+    c.first_name,
+    c.last_name_or_company
+  from public.caretakers c
+  where lower(c.login) = lower(p_login)
+  limit 1;
+$$;
+
+grant execute on function public.caretaker_login_get(text) to anon;
+
+-- Polityki RLS umożliwiające odczyt danych opiekuna po nadaniu claimu caretaker_id.
+drop policy if exists "Caretaker can read self" on public.caretakers;
+create policy "Caretaker can read self"
+  on public.caretakers
+  for select
+  to anon
+  using (
+    (current_setting('request.jwt.claims', true)::jsonb ->> 'caretaker_id')::uuid = id
+  );
+
+drop policy if exists "Caretaker can see assigned facilities" on public.facility_caretakers;
+create policy "Caretaker can see assigned facilities"
+  on public.facility_caretakers
+  for select
+  to anon
+  using (
+    (current_setting('request.jwt.claims', true)::jsonb ->> 'caretaker_id')::uuid = caretaker_id
+  );
+
+-- Funkcja zwracająca rezerwacje przypisane do opiekuna po zweryfikowaniu skrótu hasła.
+drop function if exists public.caretaker_reservations_secure(text, text);
+create or replace function public.caretaker_reservations_secure(p_login text, p_password_hash text)
+returns table (
+  caretaker_id uuid,
+  caretaker_login text,
+  facility_id uuid,
+  facility_name text,
+  booking_id uuid,
+  booking_start timestamptz,
+  booking_end timestamptz,
+  booking_status text,
+  booking_title text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  auth_caretaker public.caretakers%rowtype;
+begin
+  select *
+  into auth_caretaker
+  from public.caretakers
+  where lower(login) = lower(p_login)
+  limit 1;
+
+  if auth_caretaker.id is null then
+    return;
+  end if;
+
+  if auth_caretaker.password_hash <> p_password_hash then
+    return;
+  end if;
+
+  return query
+  select
+    auth_caretaker.id as caretaker_id,
+    auth_caretaker.login as caretaker_login,
+    fc.facility_id,
+    f.name as facility_name,
+    b.id as booking_id,
+    b.start_time as booking_start,
+    b.end_time as booking_end,
+    b.status as booking_status,
+    b.title as booking_title
+  from public.facility_caretakers fc
+  join public.facilities f on f.id = fc.facility_id
+  left join public.bookings b on b.facility_id = fc.facility_id
+  where fc.caretaker_id = auth_caretaker.id;
+end;
+$$;
+
+grant execute on function public.caretaker_reservations_secure(text, text) to anon;


### PR DESCRIPTION
## Summary
- add a dedicated caretaker login page and script that verifies hashed credentials and stores a signed session token in browser storage
- require a valid caretaker session across admin tooling, adding a logout action and linking the new login page across navigation
- extend the Supabase caretaker schema with helper functions and RLS policies for authenticated data access

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1594393508322bc9adbc588f0d553