### PR TITLE
Update gallery info message to neutral wording

### DIFF
--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -332,7 +332,7 @@ export function createFacilitiesModule({
     infoEl.classList.remove('text-red-600');
 
     if (hasImages) {
-      infoEl.textContent = 'Linki do zdjęć są przechowywane w Supabase.';
+      infoEl.textContent = 'Galeria zawiera zapisane linki do zdjęć.';
     } else {
       infoEl.textContent = 'Brak zapisanych linków do zdjęć.';
     }


### PR DESCRIPTION
## Summary
- replace the gallery information message with a neutral description instead of referencing Supabase
- reviewed other Supabase strings for gallery-specific mentions and found no further updates necessary

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1625d2360832290ebd5fa777e9de2