### PR TITLE
Adjust facility gallery layout for desktop grid

### DIFF
--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -296,7 +296,7 @@ export function createFacilitiesModule({
           .map((url, idx) => `
             <button
               type="button"
-              class="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-xl border-2 focus:outline-none focus:ring-2 focus:ring-blue-500 ${idx === 0 ? 'border-blue-500 ring-2 ring-blue-500' : 'border-transparent'}"
+              class="relative w-16 h-16 overflow-hidden rounded-xl border-2 focus:outline-none focus:ring-2 focus:ring-blue-500 md:w-full md:h-auto md:flex-shrink md:aspect-square ${idx === 0 ? 'border-blue-500 ring-2 ring-blue-500' : 'border-transparent'}"
               data-index="${idx}"
               aria-label="Podgląd zdjęcia ${idx + 1} z ${images.length}"
             >

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -89,7 +89,10 @@ export function renderMain() {
                     Otwórz galerię
                   </button>
                 </div>
-                <div id="facilityThumbs" class="hidden flex gap-2 overflow-x-auto pb-1"></div>
+                <div
+                  id="facilityThumbs"
+                  class="hidden flex gap-2 overflow-x-auto pb-1 md:grid md:grid-cols-[repeat(auto-fit,minmax(6rem,1fr))] md:gap-3 md:overflow-visible md:pb-0"
+                ></div>
                 <div id="galleryColumnInfo" class="text-xs leading-snug text-slate-500">
                   Wybierz świetlicę, aby zobaczyć zdjęcia.
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -183,3 +183,24 @@ body.intro-video-open {
     width: min(40vw, 440px);
   }
 }
+
+@media (min-width: 1024px) {
+  #facilityThumbs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+    gap: 0.75rem;
+    overflow: visible;
+  }
+
+  #facilityThumbs button {
+    aspect-ratio: 1 / 1;
+    border-color: rgba(125, 211, 252, 0.6);
+    box-shadow:
+      0 0 0 1px rgba(125, 211, 252, 0.6),
+      0 10px 24px rgba(59, 130, 246, 0.12);
+  }
+
+  #facilityThumbs button.border-blue-500 {
+    border-color: #3b82f6;
+  }
+}


### PR DESCRIPTION
## Summary
- arrange the facility thumbnail container as a responsive grid on desktop breakpoints
- let thumbnail buttons grow responsively while keeping mobile sizing intact
- add desktop media query styling to align the thumbnail grid, set square tiles, and provide lighter borders with soft shadows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d164dbeb8c83229516e64122b4ac1b