### PR TITLE
Ensure facility gallery desktop grid merges cleanly

### DIFF
--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -309,6 +309,10 @@ export function createFacilitiesModule({
             </button>
           `)
           .join('');
+        thumbs.querySelectorAll('button[data-index]').forEach((btn) => {
+          btn.classList.remove('flex-shrink-0');
+          btn.classList.add('md:w-full', 'md:h-auto', 'md:flex-shrink', 'md:aspect-square');
+        });
         thumbs.classList.remove('hidden');
       } else {
         thumbs.innerHTML = '';

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -323,4 +323,14 @@ export function renderMain() {
       </div>
     </div>
   `;
+  const thumbs = root.querySelector('#facilityThumbs');
+  if (thumbs) {
+    thumbs.classList.add(
+      'md:grid',
+      'md:grid-cols-[repeat(auto-fit,minmax(6rem,1fr))]',
+      'md:gap-3',
+      'md:overflow-visible',
+      'md:pb-0',
+    );
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -183,3 +183,24 @@ body.intro-video-open {
     width: min(40vw, 440px);
   }
 }
+
+@media (min-width: 1024px) {
+  #facilityThumbs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+    gap: 0.75rem;
+    overflow: visible;
+  }
+
+  #facilityThumbs button {
+    aspect-ratio: 1 / 1;
+    border-color: rgba(125, 211, 252, 0.6);
+    box-shadow:
+      0 0 0 1px rgba(125, 211, 252, 0.6),
+      0 10px 24px rgba(59, 130, 246, 0.12);
+  }
+
+  #facilityThumbs button.border-blue-500 {
+    border-color: #3b82f6;
+  }
+}


### PR DESCRIPTION
## Summary
- add the desktop grid utility classes to the facility thumbnail container after render to avoid markup conflicts while preserving mobile styling
- update gallery thumbnail buttons after they are injected so the mobile classes stay intact while desktop sizing, aspect, and shrink behavior kick in
- keep the large-screen CSS that enforces the grid layout and square tiles with lighter borders and shadows for desktop clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d164dbeb8c83229516e64122b4ac1b