### PR TITLE
Use single caretaker header

### DIFF
--- a/js/caretakers/supabaseClient.js
+++ b/js/caretakers/supabaseClient.js
@@ -23,8 +23,7 @@ function mergeGlobalOptions(baseOptions = {}, caretakerId) {
     : {};
 
   if (caretakerId) {
-    headers['x-caretaker-id'] = caretakerId;
-    headers['X-Caretaker-Id'] = caretakerId;
+    headers['x-caretaker-id'] = caretakerId; // Header names are case-insensitive
   }
 
   return {


### PR DESCRIPTION
## Summary
- ensure the caretaker Supabase client only sends the lowercase `x-caretaker-id` header
- document that header names are case-insensitive to explain the single entry

## Testing
- Playwright script: register caretaker, log in, attempt facility insert (REST calls carry only the lowercase `x-caretaker-id`; insert still blocked by facilities RLS)


------
https://chatgpt.com/codex/tasks/task_e_68d46be179a88322bcd0c2d35bc86a8e