### PR TITLE
Add backend session synchronization for caretaker login

### DIFF
--- a/js/caretakers/backendSession.js
+++ b/js/caretakers/backendSession.js
@@ -1,0 +1,51 @@
+import { BACKEND_SET_SESSION_PATH, resolveBackendUrl } from '../config/backendClient.js';
+
+function isJsonResponse(response) {
+  const contentType = response.headers?.get?.('content-type') || '';
+  return typeof contentType === 'string' && contentType.toLowerCase().includes('application/json');
+}
+
+export async function syncCaretakerBackendSession(token, { signal } = {}) {
+  if (!token) {
+    return null;
+  }
+
+  const endpoint = resolveBackendUrl(BACKEND_SET_SESSION_PATH);
+  if (!endpoint) {
+    console.warn('Nie udało się określić adresu backendu do synchronizacji sesji.');
+    return null;
+  }
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ token }),
+      signal,
+    });
+
+    if (!response.ok) {
+      const details = await response.text().catch(() => '');
+      const error = new Error(
+        `Backend sesji zwrócił błąd ${response.status}: ${response.statusText || 'Nieznany błąd'}`
+      );
+      if (details) {
+        error.details = details;
+      }
+      throw error;
+    }
+
+    if (isJsonResponse(response)) {
+      return response.json().catch(() => null);
+    }
+    return null;
+  } catch (error) {
+    console.error('Błąd synchronizacji sesji z backendem:', error);
+    throw error;
+  }
+}
+
+export default syncCaretakerBackendSession;

--- a/js/caretakers/login.js
+++ b/js/caretakers/login.js
@@ -5,6 +5,7 @@ import {
   getCaretakerSession,
   saveCaretakerSession,
 } from './session.js';
+import { syncCaretakerBackendSession } from './backendSession.js';
 import { $ } from '../utils/dom.js';
 
 const supabase = createSupabaseClient();
@@ -165,8 +166,15 @@ async function handleSubmit(event) {
       setMessage('Nieprawidłowy login lub hasło.', 'error');
       return;
     }
-    const session = await saveCaretakerSession(caretaker);
+    const { session, token } = await saveCaretakerSession(caretaker);
     updateUiForSession(session);
+    if (token) {
+      try {
+        await syncCaretakerBackendSession(token);
+      } catch (syncError) {
+        console.warn('Nie udało się przekazać sesji do backendu:', syncError);
+      }
+    }
     const displayName = getCaretakerDisplayName(session) || session.login;
     setMessage(`Zalogowano jako ${displayName}. Przekierowanie...`, 'success');
     const redirectTarget = resolveRedirectTarget();

--- a/js/config/backendClient.js
+++ b/js/config/backendClient.js
@@ -1,0 +1,29 @@
+const RAW_BACKEND_API_URL = window.__SUPA?.BACKEND_API_URL || window.__SUPA?.BACKEND_URL || '';
+const BACKEND_API_URL = typeof RAW_BACKEND_API_URL === 'string' ? RAW_BACKEND_API_URL.trim() : '';
+
+const DEFAULT_SESSION_PATH = '/api/auth/set-session';
+const RAW_SESSION_PATH = window.__SUPA?.BACKEND_SET_SESSION_PATH || window.__SUPA?.BACKEND_SESSION_ENDPOINT;
+const BACKEND_SET_SESSION_PATH = typeof RAW_SESSION_PATH === 'string' && RAW_SESSION_PATH.trim()
+  ? RAW_SESSION_PATH.trim()
+  : DEFAULT_SESSION_PATH;
+
+export function resolveBackendUrl(path = '/') {
+  const targetPath = typeof path === 'string' && path.trim() ? path.trim() : '/';
+  if (!BACKEND_API_URL) {
+    return targetPath;
+  }
+  try {
+    return new URL(targetPath, BACKEND_API_URL).toString();
+  } catch (error) {
+    console.warn('Nie udało się zbudować adresu backendu:', error);
+    return targetPath;
+  }
+}
+
+export { BACKEND_API_URL, BACKEND_SET_SESSION_PATH };
+
+export default {
+  BACKEND_API_URL,
+  BACKEND_SET_SESSION_PATH,
+  resolveBackendUrl,
+};

--- a/supabase-config.js
+++ b/supabase-config.js
@@ -2,4 +2,7 @@ window.__SUPA = {
   SUPABASE_URL: "https://zqrzdmvzrixnyvoejtty.supabase.co",   // ← podmień
   SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InpxcnpkbXZ6cml4bnl2b2VqdHR5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMDM5MTMsImV4cCI6MjA3MzY3OTkxM30.DVreHVIg-gyCCRq1699Jfe5uRsV8OmaHpUuH-63IN_U",          // ← podmień
   GOOGLE_MAPS_API_KEY: "YOUR-GOOGLE-MAPS-API-KEY"     // ← opcjonalnie
+  // Opcjonalnie: adres backendu obsługującego synchronizację sesji.
+  // BACKEND_API_URL: "https://twoj-backend.example.com",
+  // BACKEND_SET_SESSION_PATH: "/api/auth/set-session",
 };


### PR DESCRIPTION
## Summary
- add a backend session sync call during caretaker login to forward the signed token
- expose session token utilities and a backend config helper for resolving the sync endpoint
- document optional backend configuration entries in `supabase-config.js`

## Testing
- not run (front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68d473afdd788322bbf0a0be9f43dc14