### PR TITLE
Add script to drop public schema cascade

### DIFF
--- a/schema_drop.sql
+++ b/schema_drop.sql
@@ -1,0 +1,19 @@
+-- Resetuje schemat public usuwając wszystkie obiekty (tabele, funkcje, trigery itp.).
+-- Po uruchomieniu ponownie zastosuj schema.sql lub inne skrypty odtwarzające strukturę bazy.
+
+begin;
+
+-- Usuń rozszerzenia zależne od schematu public (np. pgcrypto).
+drop extension if exists "pgcrypto" cascade;
+
+-- Usuń cały schemat wraz z powiązanymi obiektami.
+drop schema if exists public cascade;
+
+-- Utwórz ponownie pusty schemat public.
+create schema public;
+
+-- Przywróć standardowe uprawnienia dla schematu public.
+grant usage on schema public to public;
+grant all on schema public to postgres, pg_database_owner;
+
+commit;


### PR DESCRIPTION
## Summary
- add a utility SQL script that drops the public schema with cascade
- recreate the schema and restore default grants so the database can be rebuilt cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d515a432f88322ae988496fd18a62d