### PR TITLE
Refactor caretaker auth to Supabase sessions

### DIFF
--- a/js/admin/bookingsDashboard.js
+++ b/js/admin/bookingsDashboard.js
@@ -1,4 +1,3 @@
-import { createCaretakerSupabaseClient } from '../caretakers/supabaseClient.js';
 import { requireCaretakerSession } from '../caretakers/session.js';
 import { escapeHtml, formatDate, formatTime } from '../utils/format.js';
 
@@ -550,8 +549,7 @@ async function bootstrap() {
   if (!session) {
     return;
   }
-  const caretakerId = session?.caretakerId || session?.id || null;
-  const supabase = createCaretakerSupabaseClient({ caretakerId });
+  const supabase = session?.supabase || null;
   if (!supabase) {
     setMessage('Brak konfiguracji Supabase lub identyfikatora opiekuna. Uzupełnij dane połączenia.', 'error');
     return;

--- a/js/admin/editDescriptionPage.js
+++ b/js/admin/editDescriptionPage.js
@@ -1,5 +1,4 @@
 import { clearCaretakerSession, requireCaretakerSession } from '../caretakers/session.js';
-import { createCaretakerSupabaseClient } from '../caretakers/supabaseClient.js';
 import { INSTRUCTION_FIELDS, findInstructionInfo } from '../utils/instructions.js';
 import { initFacilityForm } from './facilityForm.js';
 
@@ -75,13 +74,15 @@ async function bootstrap() {
 
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {
-      clearCaretakerSession();
-      window.location.replace('./caretakerLogin.html');
+      void (async () => {
+        await clearCaretakerSession();
+        window.location.replace('./caretakerLogin.html');
+      })();
     });
   }
 
-  const caretakerId = session?.caretakerId || session?.id || null;
-  const supa = createCaretakerSupabaseClient({ caretakerId });
+  const caretakerId = session?.caretakerId || null;
+  const supa = session?.supabase || null;
   if (!supa) {
     setStatus(messageEl, 'Brak konfiguracji Supabase lub identyfikatora opiekuna.', 'error');
     return;
@@ -812,8 +813,7 @@ async function bootstrap() {
   }
 
   initFacilityForm({
-    supabase: supa,
-    caretakerId,
+    session,
     onFacilityCreated: async (createdFacility) => {
       const facilityId = createdFacility?.id ? String(createdFacility.id) : null;
       await loadFacilities({ selectId: facilityId, silent: true });

--- a/js/admin/facilityForm.js
+++ b/js/admin/facilityForm.js
@@ -166,13 +166,17 @@ function collectPayload(form) {
 }
 
 export function initFacilityForm({
-  supabase,
+  session = null,
+  supabase: suppliedSupabase,
   form = document.getElementById('addFacilityForm'),
   submitButton = document.getElementById('addFacilitySubmit'),
   messageElement = document.getElementById('addFacilityMessage'),
   onFacilityCreated,
-  caretakerId = null,
+  caretakerId: suppliedCaretakerId,
 } = {}) {
+  const supabase = suppliedSupabase || session?.supabase || null;
+  const caretakerId =
+    suppliedCaretakerId !== undefined ? suppliedCaretakerId : session?.caretakerId ?? null;
   if (!form) {
     return { destroy() {}, reset() {} };
   }
@@ -282,4 +286,3 @@ export function initFacilityForm({
   };
 }
 
-export default initFacilityForm;


### PR DESCRIPTION
## Summary
- switch the caretaker login flow to Supabase email/password auth and reuse refreshed profile data
- replace the bespoke caretaker session store with Supabase-auth backed session management
- update admin modules to consume the new session layer and derive configured Supabase clients

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d51d96abf48322ad705df036bd5e37