### PR TITLE
Use caretaker_exists in facilities insert policy

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -337,11 +337,7 @@ create policy "Caretaker insert facilities"
   for insert
   to authenticated
   with check (
-    exists (
-      select 1
-      from public.caretakers c
-      where c.id = auth.uid()
-    )
+    public.caretaker_exists(auth.uid())
   );
 
 drop policy if exists "Caretaker update facilities" on public.facilities;


### PR DESCRIPTION
## Summary
- update the facilities insert RLS policy to defer caretaker validation to the caretaker_exists helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d531954fdc832286eb6459a0fe787f