### PR TITLE
Avoid duplicate Supabase clients on caretaker login

### DIFF
--- a/js/caretakers/login.js
+++ b/js/caretakers/login.js
@@ -1,9 +1,8 @@
-import { createSupabaseClient } from '../config/supabaseClient.js';
-import { clearCaretakerSession, getCaretakerDisplayName, getCaretakerSession } from './session.js';
+import { clearCaretakerSession, getCaretakerDisplayName, getCaretakerSession, getBaseSupabaseClient } from './session.js';
 import { syncCaretakerBackendSession } from './backendSession.js';
 import { $ } from '../utils/dom.js';
 
-const supabase = createSupabaseClient();
+const supabase = getBaseSupabaseClient();
 
 const form = $('#caretakerLoginForm');
 const messageEl = $('#caretakerLoginMessage');

--- a/js/caretakers/session.js
+++ b/js/caretakers/session.js
@@ -46,6 +46,10 @@ function ensureSupabaseClient() {
   return baseSupabase;
 }
 
+export function getBaseSupabaseClient() {
+  return ensureSupabaseClient();
+}
+
 function extractMetadata(user) {
   const metadata = user?.user_metadata || {};
   return {


### PR DESCRIPTION
## Summary
- expose a helper in the caretaker session module to reuse the shared Supabase client
- switch the caretaker login page to use the shared client so only one GoTrue instance is created

## Testing
- curl -I http://127.0.0.1:8000/caretakerLogin.html

------
https://chatgpt.com/codex/tasks/task_e_68d533c29b74832289de9180ba1d45db