### PR TITLE
Guard caretaker session sync from duplicate requests

### DIFF
--- a/js/caretakers/backendSession.js
+++ b/js/caretakers/backendSession.js
@@ -44,6 +44,53 @@ function normalizeSessionPayload(sessionLike) {
   return payload;
 }
 
+function createAbortReason(message) {
+  if (typeof DOMException === 'function') {
+    return new DOMException(message, 'AbortError');
+  }
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
+
+function attachExternalSignal(controller, signal) {
+  if (!signal || !controller || typeof controller.abort !== 'function') {
+    return;
+  }
+  if (signal.aborted) {
+    controller.abort(signal.reason);
+    return;
+  }
+  const abortHandler = () => {
+    controller.abort(signal.reason);
+  };
+  signal.addEventListener('abort', abortHandler, { once: true });
+}
+
+function getPayloadSignature(payload) {
+  try {
+    return JSON.stringify(payload);
+  } catch (error) {
+    console.warn('Nie udało się zserializować payloadu sesji do synchronizacji:', error);
+    return null;
+  }
+}
+
+const activeSyncState = {
+  controller: null,
+  promise: null,
+  payloadSignature: null,
+};
+
+function resetActiveSyncState(promiseRef) {
+  if (promiseRef && activeSyncState.promise !== promiseRef) {
+    return;
+  }
+  activeSyncState.controller = null;
+  activeSyncState.promise = null;
+  activeSyncState.payloadSignature = null;
+}
+
 export async function syncCaretakerBackendSession(sessionTokens, { signal } = {}) {
   const payload = normalizeSessionPayload(sessionTokens);
   if (!payload) {
@@ -56,36 +103,68 @@ export async function syncCaretakerBackendSession(sessionTokens, { signal } = {}
     return null;
   }
 
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-      signal,
-    });
+  const payloadSignature = getPayloadSignature(payload);
 
-    if (!response.ok) {
-      const details = await response.text().catch(() => '');
-      const error = new Error(
-        `Backend sesji zwrócił błąd ${response.status}: ${response.statusText || 'Nieznany błąd'}`
-      );
-      if (details) {
-        error.details = details;
+  if (activeSyncState.promise && payloadSignature && activeSyncState.payloadSignature === payloadSignature) {
+    attachExternalSignal(activeSyncState.controller, signal);
+    return activeSyncState.promise;
+  }
+
+  if (activeSyncState.controller) {
+    try {
+      activeSyncState.controller.abort(createAbortReason('Nowa próba synchronizacji sesji opiekuna.'));
+    } catch (abortError) {
+      console.warn('Nie udało się anulować poprzedniej synchronizacji sesji:', abortError);
+    }
+  }
+
+  const controller = new AbortController();
+  attachExternalSignal(controller, signal);
+
+  const rawPromise = (async () => {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const details = await response.text().catch(() => '');
+        const error = new Error(
+          `Backend sesji zwrócił błąd ${response.status}: ${response.statusText || 'Nieznany błąd'}`
+        );
+        if (details) {
+          error.details = details;
+        }
+        throw error;
+      }
+
+      if (isJsonResponse(response)) {
+        return response.json().catch(() => null);
+      }
+      return null;
+    } catch (error) {
+      if (error?.name !== 'AbortError') {
+        console.error('Błąd synchronizacji sesji z backendem:', error);
       }
       throw error;
     }
+  })();
 
-    if (isJsonResponse(response)) {
-      return response.json().catch(() => null);
-    }
-    return null;
-  } catch (error) {
-    console.error('Błąd synchronizacji sesji z backendem:', error);
-    throw error;
-  }
+  const trackedPromise = rawPromise.finally(() => {
+    resetActiveSyncState(trackedPromise);
+  });
+
+  activeSyncState.controller = controller;
+  activeSyncState.promise = trackedPromise;
+  activeSyncState.payloadSignature = payloadSignature;
+
+  return trackedPromise;
 }
 
 export default syncCaretakerBackendSession;


### PR DESCRIPTION
## Summary
- prevent multiple concurrent caretaker session synchronisation requests from stacking up
- reuse the in-flight synchronisation when the payload matches and cancel any stale request
- improve abort handling and logging around backend session synchronisation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5383f22ec832296fe4b4500e966ce