### PR TITLE
Add Supabase auth test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Ten pakiet zawiera działające MVP:
 - W nagłówku aplikacji dostępny jest link „Zarejestruj opiekuna”, który prowadzi do formularza `registerCaretaker.html`.
 - Formularz zapisuje dane do tabeli `caretakers` oraz przypisania w tabeli `facility_caretakers`.
 - Wszystkie funkcje pomocnicze i polityki RLS wymagane do obsługi opiekunów są częścią `schema.sql`.
+
+## Test środowiska Supabase
+Dla szybkiego sprawdzenia konfiguracji Supabase dodano stronę `supabase-test.html`. Umożliwia ona zalogowanie się przez Supabase Auth oraz dodanie przykładowej encji nieruchomości do tabeli `properties`. Po ustawieniu w `supabase-config.js` poprawnych wartości `SUPABASE_URL` i `SUPABASE_ANON_KEY`:
+
+1. Otwórz `supabase-test.html` w przeglądarce.
+2. Zaloguj się przy użyciu konta użytkownika z Supabase Auth.
+3. Po zalogowaniu wypełnij formularz „Dodaj nieruchomość” i zapisz wpis.
+
+Aby przygotować tabelę testową wraz z podstawowymi politykami RLS, uruchom skrypt `supabase-test-properties.sql` w edytorze SQL Supabase. Tabela `properties` utworzona przez skrypt zawiera kolumny `title`, `address`, `description`, `price` (NUMERIC), a także informacje o właścicielu rekordu. Dzięki temu można łatwo zweryfikować poprawność konfiguracji bazy i uwierzytelniania.

--- a/js/supabaseTest.js
+++ b/js/supabaseTest.js
@@ -1,0 +1,117 @@
+const config = window.__SUPA;
+if (!config?.SUPABASE_URL || !config?.SUPABASE_ANON_KEY) {
+  throw new Error("Brak konfiguracji Supabase. Uzupełnij plik supabase-config.js.");
+}
+
+const supabase = window.supabase.createClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});
+
+const authSection = document.querySelector('#auth-section');
+const propertySection = document.querySelector('#property-section');
+const authMessage = document.querySelector('#auth-message');
+const propertyMessage = document.querySelector('#property-message');
+const loginForm = document.querySelector('#login-form');
+const propertyForm = document.querySelector('#property-form');
+const logoutButton = document.querySelector('#logout-button');
+
+const showAuth = () => {
+  authSection.classList.remove('hidden');
+  propertySection.classList.add('hidden');
+  loginForm.reset();
+};
+
+const showPropertyForm = (session) => {
+  authSection.classList.add('hidden');
+  propertySection.classList.remove('hidden');
+  propertyMessage.textContent = `Zalogowano jako ${session.user.email}`;
+  propertyMessage.classList.remove('text-rose-600');
+  propertyMessage.classList.add('text-emerald-600');
+};
+
+const checkSession = async () => {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    console.error('Błąd pobierania sesji', error);
+    authMessage.textContent = 'Nie udało się pobrać sesji. Spróbuj ponownie.';
+    return;
+  }
+
+  if (data.session) {
+    showPropertyForm(data.session);
+  } else {
+    showAuth();
+  }
+};
+
+loginForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  authMessage.textContent = '';
+
+  const formData = new FormData(loginForm);
+  const email = formData.get('email');
+  const password = formData.get('password');
+
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    authMessage.textContent = error.message;
+    return;
+  }
+
+  await checkSession();
+});
+
+logoutButton.addEventListener('click', async () => {
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    propertyMessage.textContent = error.message;
+    propertyMessage.classList.remove('text-emerald-600');
+    propertyMessage.classList.add('text-rose-600');
+    return;
+  }
+
+  propertyMessage.textContent = 'Wylogowano pomyślnie.';
+  propertyMessage.classList.remove('text-rose-600');
+  propertyMessage.classList.add('text-slate-600');
+  showAuth();
+});
+
+propertyForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  propertyMessage.textContent = '';
+  propertyMessage.classList.remove('text-rose-600', 'text-emerald-600', 'text-slate-600');
+
+  const formData = new FormData(propertyForm);
+  const payload = {
+    title: formData.get('title'),
+    address: formData.get('address'),
+    description: formData.get('description'),
+    price: parseFloat(formData.get('price')),
+  };
+
+  const { error } = await supabase.from('properties').insert(payload);
+
+  if (error) {
+    propertyMessage.textContent = `Błąd zapisu: ${error.message}`;
+    propertyMessage.classList.add('text-rose-600');
+    return;
+  }
+
+  propertyMessage.textContent = 'Nieruchomość została zapisana.';
+  propertyMessage.classList.add('text-emerald-600');
+  propertyForm.reset();
+});
+
+checkSession();
+
+supabase.auth.onAuthStateChange((_event, session) => {
+  if (session) {
+    showPropertyForm(session);
+  } else {
+    showAuth();
+  }
+});

--- a/supabase-test-properties.sql
+++ b/supabase-test-properties.sql
@@ -1,0 +1,51 @@
+-- Przed uruchomieniem upewnij się, że masz włączone rozszerzenie pgcrypto.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists public.properties (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  address text not null,
+  description text not null,
+  price numeric(12,2) not null,
+  created_at timestamptz not null default now(),
+  created_by uuid references auth.users(id)
+);
+
+alter table public.properties enable row level security;
+
+create policy if not exists "Properties insert for authenticated users"
+  on public.properties
+  for insert
+  with check (auth.uid() is not null);
+
+create policy if not exists "Properties select for owners"
+  on public.properties
+  for select
+  using (created_by = auth.uid());
+
+create policy if not exists "Properties update for owners"
+  on public.properties
+  for update
+  using (created_by = auth.uid());
+
+create policy if not exists "Properties delete for owners"
+  on public.properties
+  for delete
+  using (created_by = auth.uid());
+
+create or replace function public.properties_set_owner()
+returns trigger as $$
+begin
+  if new.created_by is null then
+    new.created_by := auth.uid();
+  end if;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+drop trigger if exists set_properties_owner on public.properties;
+
+create trigger set_properties_owner
+before insert on public.properties
+for each row execute function public.properties_set_owner();

--- a/supabase-test.html
+++ b/supabase-test.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Test środowiska Supabase</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-slate-100 text-slate-900">
+    <main class="mx-auto flex max-w-2xl flex-col gap-8 px-4 py-10">
+      <header class="space-y-2 text-center">
+        <h1 class="text-3xl font-semibold">Środowisko testowe Supabase</h1>
+        <p class="text-sm text-slate-600">
+          Zaloguj się przy użyciu Supabase Auth, aby uzyskać dostęp do formularza dodawania nieruchomości.
+        </p>
+      </header>
+
+      <section id="auth-section" class="rounded-xl bg-white p-6 shadow">
+        <h2 class="mb-4 text-xl font-medium">Logowanie</h2>
+        <form id="login-form" class="space-y-4">
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Adres e-mail</span>
+            <input
+              type="email"
+              name="email"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="jan.kowalski@example.com"
+            />
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Hasło</span>
+            <input
+              type="password"
+              name="password"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="••••••••"
+            />
+          </label>
+          <button
+            type="submit"
+            class="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500 focus:outline-none focus:ring"
+          >
+            Zaloguj się
+          </button>
+        </form>
+        <p id="auth-message" class="mt-3 text-sm text-rose-600" role="alert"></p>
+      </section>
+
+      <section id="property-section" class="hidden rounded-xl bg-white p-6 shadow">
+        <div class="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-medium">Dodaj nieruchomość</h2>
+            <p class="text-sm text-slate-600">Formularz dostępny tylko dla zalogowanych użytkowników.</p>
+          </div>
+          <button
+            id="logout-button"
+            class="rounded-lg border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            type="button"
+          >
+            Wyloguj się
+          </button>
+        </div>
+        <form id="property-form" class="space-y-4">
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Tytuł ogłoszenia</span>
+            <input
+              type="text"
+              name="title"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="Przestronne mieszkanie w centrum"
+            />
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Adres</span>
+            <input
+              type="text"
+              name="address"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="ul. Słoneczna 15, Warszawa"
+            />
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Opis</span>
+            <textarea
+              name="description"
+              rows="4"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="Nowoczesne, w pełni wyposażone mieszkanie..."
+            ></textarea>
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-sm font-medium text-slate-700">Cena miesięczna (PLN)</span>
+            <input
+              type="number"
+              name="price"
+              min="0"
+              step="0.01"
+              required
+              class="w-full rounded-lg border border-slate-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring"
+              placeholder="3200"
+            />
+          </label>
+          <button
+            type="submit"
+            class="w-full rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500 focus:outline-none focus:ring"
+          >
+            Zapisz nieruchomość
+          </button>
+        </form>
+        <p id="property-message" class="mt-3 text-sm" role="status"></p>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="./supabase-config.js"></script>
+    <script type="module" src="./js/supabaseTest.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Supabase test page with login and property form gated by authentication
- implement simple Supabase client logic for signing in, signing out, and inserting new property records
- document how to use the new page to verify Supabase configuration, including a dedicated SQL script for the `properties` table
- provide a reusable SQL script that creates the `properties` table with basic RLS policies for the Supabase test page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b135cf4c8322b8ec022285cc3ef4