### PR TITLE
Add Supabase grants for properties table access

### DIFF
--- a/supabase-test-properties.sql
+++ b/supabase-test-properties.sql
@@ -12,6 +12,9 @@ create table if not exists public.properties (
   created_by uuid references auth.users(id)
 );
 
+grant select, insert, update, delete on table public.properties to authenticated;
+grant select, insert, update, delete on table public.properties to anon;
+
 alter table public.properties enable row level security;
 
 create policy if not exists "Properties insert for authenticated users"


### PR DESCRIPTION
## Summary
- grant CRUD permissions on the properties table to the authenticated role
- extend the same permissions to the anon role for optional anonymous form access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d651d716948322b308e152d99fbb12