### PR TITLE
Remove invalid caretaker instructions column fallback

### DIFF
--- a/js/utils/instructions.js
+++ b/js/utils/instructions.js
@@ -1,6 +1,5 @@
 export const INSTRUCTION_FIELDS = [
   'caretaker_instructions',
-  'caretaker_instruction',
   'caretaker_notes',
   'instructions',
   'instructions_text',


### PR DESCRIPTION
## Summary
- stop referencing the non-existent `caretaker_instruction` column when editing caretaker instructions so the page updates the correct field

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66d90fe5483229eaca441107e2c86