### PR TITLE
Adjust home page styling for cooler beige and tighter radii

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <!-- Style własne -->
   <link rel="stylesheet" href="./styles.css">
 </head>
-<body class="bg-[#f2efe8] text-gray-900" data-intro-video-src="./assets/intro.mp4">
+<body class="bg-[#f1f3ef] text-gray-900" data-intro-video-src="./assets/intro.mp4">
   <!-- Nagłówek -->
   <header class="p-4 bg-white shadow">
     <div class="max-w-6xl mx-auto flex items-center justify-between gap-4 flex-wrap">
@@ -23,13 +23,13 @@
         <div class="text-gray-500">🦉 SOWA System Online do Wsparcia Automatycznej rezerwacji świetlic</div>
         <a
           href="./caretakerLogin.html"
-          class="inline-flex items-center gap-1 rounded-xl border border-indigo-200 px-3 py-1 font-medium text-indigo-700 hover:bg-indigo-50"
+          class="inline-flex items-center gap-1 rounded-md border border-indigo-200 px-3 py-1 font-medium text-indigo-700 hover:bg-indigo-50"
         >
           Panel opiekuna
         </a>
         <a
           href="./registerCaretaker.html"
-          class="inline-flex items-center gap-1 rounded-xl border border-amber-200 px-3 py-1 font-medium text-amber-700 hover:bg-amber-50"
+          class="inline-flex items-center gap-1 rounded-md border border-amber-200 px-3 py-1 font-medium text-amber-700 hover:bg-amber-50"
         >
           Zarejestruj opiekuna
         </a>

--- a/styles.css
+++ b/styles.css
@@ -3,12 +3,12 @@
 .main-shell {
   position: relative;
   isolation: isolate;
-  border-radius: 40px;
-  background-color: #f2efe8;
+  border-radius: 16px;
+  background-color: #f1f3ef;
   background-image:
-    radial-gradient(120% 120% at 0% 0%, rgba(223, 220, 214, 0.55), rgba(242, 240, 233, 0.95)),
-    radial-gradient(140% 140% at 100% 100%, rgba(199, 209, 219, 0.35), rgba(242, 240, 233, 0.98));
-  box-shadow: 0 45px 120px rgba(170, 174, 184, 0.25);
+    radial-gradient(120% 120% at 0% 0%, rgba(206, 214, 223, 0.55), rgba(240, 242, 239, 0.95)),
+    radial-gradient(140% 140% at 100% 100%, rgba(188, 200, 212, 0.35), rgba(240, 242, 239, 0.98));
+  box-shadow: 0 45px 120px rgba(160, 170, 184, 0.22);
   overflow: hidden;
 }
 
@@ -28,7 +28,7 @@
   left: -140px;
   width: 420px;
   height: 420px;
-  background: radial-gradient(circle, rgba(202, 207, 214, 0.35), rgba(202, 207, 214, 0) 70%);
+  background: radial-gradient(circle, rgba(192, 202, 214, 0.3), rgba(192, 202, 214, 0) 70%);
 }
 
 .main-shell::after {
@@ -36,7 +36,7 @@
   right: -180px;
   width: 520px;
   height: 520px;
-  background: radial-gradient(circle, rgba(196, 189, 180, 0.3), rgba(196, 189, 180, 0) 70%);
+  background: radial-gradient(circle, rgba(176, 190, 204, 0.3), rgba(176, 190, 204, 0) 70%);
 }
 
 .main-shell > * {
@@ -46,7 +46,7 @@
 
 @media (max-width: 768px) {
   .main-shell {
-    border-radius: 28px;
+    border-radius: 12px;
   }
 
   .main-shell::before {
@@ -62,6 +62,13 @@
     bottom: -280px;
     right: -200px;
   }
+}
+
+.main-shell .rounded-3xl,
+.main-shell .rounded-2xl,
+.main-shell .rounded-xl,
+.main-shell .rounded-lg {
+  border-radius: 0.5rem !important;
 }
 
 .flow-space > .hidden + * {


### PR DESCRIPTION
## Summary
- cool down the home page shell background and gradients for a subtler beige tone
- minimize rounded corners across primary home page containers and header links for a crisper look

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6790893488322b3b32b8252981eda