### PR TITLE
Allow anonymous booking creation

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -577,6 +577,8 @@ grant execute on function public.cancel_booking(uuid) to anon, authenticated;
 
 grant select on table public.public_bookings to anon, authenticated;
 
+grant insert on table public.bookings to anon;
+
 -- Uprawnienia dla roli authenticated, wymagane do działania polityk RLS i panelu administracyjnego.
 grant usage on schema public to authenticated;
 


### PR DESCRIPTION
## Summary
- grant the anon role insert permissions on the bookings table so unauthenticated visitors can submit reservations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ff3d91b4832287f9dc5d97d70c3c