### PR TITLE
Warn weekend adjacent booking overlap warnings

### DIFF
--- a/js/booking/form.js
+++ b/js/booking/form.js
@@ -219,16 +219,13 @@ export function createBookingForm({
         return;
       }
     }
+    const startDay = new Date(startIso).getDay();
+    const isWeekendStart = startDay === 0 || startDay === 6;
     const overlap = await hasOverlap(state.selectedFacility.id, startIso, endIso);
     if (overlap) {
       setFormMessage('Wybrany termin koliduje z istniejącą rezerwacją (wstępna lub potwierdzona). Wybierz inny termin.');
       return;
     }
-    const startDateForCheck = dayValue
-      ? new Date(`${dayValue}T00:00`)
-      : new Date(startIso);
-    const startDay = startDateForCheck.getDay();
-    const isWeekendStart = startDay === 0 || startDay === 6;
     let touchesAdjacentBooking = false;
     if (isWeekendStart) {
       touchesAdjacentBooking = await hasTouchingBooking(
@@ -236,6 +233,9 @@ export function createBookingForm({
         startIso,
         endIso,
       );
+      if (touchesAdjacentBooking) {
+        setFormMessage('Trwa zapisywanie... Uwaga: rezerwacja graniczy z inną i może wymagać uzgodnień między rezerwującymi.');
+      }
     }
     updateTitleField();
 


### PR DESCRIPTION
## Summary
- determine weekend bookings directly from the reservation start timestamp
- alert users submitting weekend reservations when another booking directly touches the requested time window

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d787a7ff288322b18263ee885be823