### PR TITLE
Style booking form messages with tone-aware alerts

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -275,7 +275,7 @@ export function renderMain() {
                 Złóż wstępną rezerwację
               </button>
               <button id="cancelThisBooking" type="button" class="no-print hidden rounded-2xl border border-white/60 bg-white/70 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm shadow-amber-500/15">Anuluj tę rezerwację</button>
-              <div id="formMsg" class="text-sm text-slate-600"></div>
+              <div id="formMsg" class="hidden"></div>
             </div>
 
             <p class="text-xs text-slate-500 md:col-span-2">


### PR DESCRIPTION
## Summary
- add tone-specific styling for booking form status messages so successes render in a green frame
- update booking flow to pass explicit tones for success, error, and informational states
- hide the booking form status container until it needs to display a message

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d80770ee3c8322aaa9487d88ecb5ec