### PR TITLE
Remove legacy facilities view fallbacks

### DIFF
--- a/js/booking/form.js
+++ b/js/booking/form.js
@@ -66,7 +66,6 @@ export function createBookingForm({
   async function fetchFacilityById(facilityId) {
     const builders = [
       () => supabase.from('public_facilities').select('*').eq('id', facilityId).maybeSingle(),
-      () => supabase.from('facilities_public').select('*').eq('id', facilityId).maybeSingle(),
       () => supabase.from('facilities').select('*').eq('id', facilityId).maybeSingle(),
     ];
     for (const build of builders) {

--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -77,7 +77,6 @@ export function createFacilitiesModule({
   async function loadFacilities() {
     const facilitiesData = await runFirstSuccessfulQuery([
       () => supabase.from('public_facilities').select('*').order('name'),
-      () => supabase.from('facilities_public').select('*').order('name'),
       () => supabase.from('facilities').select('*').order('name'),
     ], { allowEmpty: false });
     state.facilities = facilitiesData || [];


### PR DESCRIPTION
## Summary
- remove references to the legacy `facilities_public` view in public data loaders
- rely on the `public_facilities` view, falling back only to the base table when needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80c1f3f08832298090ae7b77f0fe8