### PR TITLE
Add RLS policy for anonymous booking inserts

### DIFF
--- a/SQL_Updates/2024-06-02_add_bookings_anon_insert_policy.sql
+++ b/SQL_Updates/2024-06-02_add_bookings_anon_insert_policy.sql
@@ -1,0 +1,26 @@
+-- Aktualizacja dodająca politykę RLS umożliwiającą składanie rezerwacji przez anonimowych użytkowników.
+-- Uruchom w środowisku produkcyjnym po wdrożeniu zmian w aplikacji.
+
+set search_path = public;
+
+alter table public.bookings enable row level security;
+
+drop policy if exists "Anonymous can create pending bookings" on public.bookings;
+create policy "Anonymous can create pending bookings"
+  on public.bookings
+  for insert
+  to anon
+  with check (
+    status = 'pending'
+    and is_public = true
+    and decision_comment is null
+    and cancelled_at is null
+  );
+
+drop policy if exists "Authenticated manage bookings" on public.bookings;
+create policy "Authenticated manage bookings"
+  on public.bookings
+  for all
+  to authenticated
+  using (true)
+  with check (true);

--- a/schema.sql
+++ b/schema.sql
@@ -541,6 +541,28 @@ create trigger bookings_set_updated_at
 before update on public.bookings
 for each row execute function public.set_updated_at();
 
+alter table public.bookings enable row level security;
+
+drop policy if exists "Anonymous can create pending bookings" on public.bookings;
+create policy "Anonymous can create pending bookings"
+  on public.bookings
+  for insert
+  to anon
+  with check (
+    status = 'pending'
+    and is_public = true
+    and decision_comment is null
+    and cancelled_at is null
+  );
+
+drop policy if exists "Authenticated manage bookings" on public.bookings;
+create policy "Authenticated manage bookings"
+  on public.bookings
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
 -- Widok uproszczonych danych rezerwacji udostępniany publicznie.
 create or replace view public.public_bookings as
 select


### PR DESCRIPTION
## Summary
- enable row level security on the bookings table
- allow anonymous users to create pending public bookings
- keep authenticated users ability to manage bookings under RLS

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d939272a488322beaf1604a1a6cf96