### PR TITLE
Remove facility gallery thumbnails

### DIFF
--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -228,22 +228,6 @@ export function createFacilitiesModule({
       .filter((part) => part && part.toLowerCase() !== 'null' && part.toLowerCase() !== 'undefined');
   }
 
-  function highlightActiveThumb(index) {
-    const thumbs = $('#facilityThumbs');
-    if (!thumbs) {
-      return;
-    }
-    thumbs.querySelectorAll('button[data-index]').forEach((btn) => {
-      if (Number(btn.dataset.index) === index) {
-        btn.classList.add('border-amber-400', 'ring-2', 'ring-amber-300');
-        btn.classList.remove('border-transparent');
-      } else {
-        btn.classList.add('border-transparent');
-        btn.classList.remove('border-amber-400', 'ring-2', 'ring-amber-300');
-      }
-    });
-  }
-
   function setMainGalleryImage(index, { skipModalUpdate = false } = {}) {
     const images = state.galleryImages || [];
     if (!images.length) {
@@ -262,7 +246,6 @@ export function createFacilitiesModule({
         mainImg.alt = `Zdjęcie obiektu ${state.selectedFacility.name}`;
       }
     }
-    highlightActiveThumb(safeIndex);
     if (!skipModalUpdate && galleryModal?.update) {
       galleryModal.update(safeIndex);
     }
@@ -275,7 +258,7 @@ export function createFacilitiesModule({
     const mainImg = $('#facilityImgMain');
     const openBtn = $('#openGalleryBtn');
     const thumbs = $('#facilityThumbs');
-    if (!mainImg || !openBtn || !thumbs) {
+    if (!mainImg || !openBtn) {
       return;
     }
     galleryListenersAttached = true;
@@ -291,16 +274,18 @@ export function createFacilitiesModule({
       }
       galleryModal?.open?.(state.galleryCurrentIndex || 0);
     });
-    thumbs.addEventListener('click', (event) => {
-      const target = event.target.closest('button[data-index]');
-      if (!target) {
-        return;
-      }
-      const idx = Number(target.dataset.index);
-      if (Number.isFinite(idx)) {
-        setMainGalleryImage(idx);
-      }
-    });
+    if (thumbs) {
+      thumbs.addEventListener('click', (event) => {
+        const target = event.target.closest('button[data-index]');
+        if (!target) {
+          return;
+        }
+        const idx = Number(target.dataset.index);
+        if (Number.isFinite(idx)) {
+          setMainGalleryImage(idx);
+        }
+      });
+    }
     document.addEventListener('gallery:index-changed', (event) => {
       const detailIndex = Number(event.detail?.index);
       if (Number.isFinite(detailIndex)) {
@@ -340,36 +325,6 @@ export function createFacilitiesModule({
         : hasImages
           ? 'Zobacz zdjęcie'
           : 'Brak zdjęć';
-    }
-
-    const thumbs = $('#facilityThumbs');
-    if (thumbs) {
-      if (images.length > 1) {
-        thumbs.innerHTML = images
-          .map((url, idx) => `
-            <button
-              type="button"
-              class="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-xl border-2 focus:outline-none focus:ring-2 focus:ring-amber-300 ${idx === 0 ? 'border-amber-400 ring-2 ring-amber-300' : 'border-transparent'}"
-              data-index="${idx}"
-              aria-label="Podgląd zdjęcia ${idx + 1} z ${images.length}"
-            >
-              <img
-                src="${escapeHtml(url)}"
-                alt="Miniatura ${idx + 1}"
-                class="w-full h-full object-cover"
-                loading="lazy"
-              />
-            </button>
-          `)
-          .join('');
-        thumbs.querySelectorAll('button[data-index]').forEach((btn) => {
-          btn.classList.add('flex-shrink-0', 'md:w-full', 'md:h-auto', 'md:flex-shrink', 'md:aspect-square');
-        });
-        thumbs.classList.remove('hidden');
-      } else {
-        thumbs.innerHTML = '';
-        thumbs.classList.add('hidden');
-      }
     }
 
     ensureGalleryListeners();

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -89,11 +89,6 @@ export function renderMain() {
                     Otwórz galerię
                   </button>
                 </div>
-                <div
-                  id="facilityThumbs"
-                  class="hidden -mx-1 flex gap-3 overflow-x-auto px-1 pb-1 snap-x snap-mandatory"
-                  aria-label="Miniatury galerii"
-                ></div>
                 <div id="galleryColumnInfo" class="text-xs leading-snug text-slate-500">
                   Wybierz świetlicę, aby zobaczyć zdjęcia.
                 </div>
@@ -357,14 +352,4 @@ export function renderMain() {
       </div>
     </div>
   `;
-  const thumbs = root.querySelector('#facilityThumbs');
-  if (thumbs) {
-    thumbs.classList.add(
-      'md:grid',
-      'md:grid-cols-[repeat(auto-fit,minmax(6rem,1fr))]',
-      'md:gap-3',
-      'md:overflow-visible',
-      'md:pb-0',
-    );
-  }
 }

--- a/styles.css
+++ b/styles.css
@@ -195,35 +195,3 @@ body.intro-video-open {
   }
 }
 
-#facilityThumbs {
-  scroll-snap-type: x proximity;
-  -webkit-overflow-scrolling: touch;
-}
-
-#facilityThumbs::-webkit-scrollbar {
-  display: none;
-}
-
-#facilityThumbs button {
-  flex: 0 0 auto;
-  scroll-snap-align: start;
-}
-
-@media (min-width: 1024px) {
-  #facilityThumbs {
-    scroll-snap-type: none;
-  }
-
-  #facilityThumbs button {
-    aspect-ratio: 1 / 1;
-    border-color: rgba(125, 211, 252, 0.6);
-    box-shadow:
-      0 0 0 1px rgba(125, 211, 252, 0.6),
-      0 10px 24px rgba(59, 130, 246, 0.12);
-  }
-
-  #facilityThumbs button.border-blue-500 {
-    border-color: #3b82f6;
-  }
-}
-


### PR DESCRIPTION
## Summary
- remove the inline thumbnail strip from the facility gallery card and leave only the main image with modal access
- simplify gallery update logic to drop thumbnail handling while keeping modal interactions intact
- delete obsolete thumbnail-specific styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9395d89088322a09212d1de003149