### PR TITLE
Remove gallery saved links message

### DIFF
--- a/js/data/facilities.js
+++ b/js/data/facilities.js
@@ -343,7 +343,7 @@ export function createFacilitiesModule({
     infoEl.classList.remove('text-red-600');
 
     if (hasImages) {
-      infoEl.textContent = 'Galeria zawiera zapisane linki do zdjęć.';
+      infoEl.textContent = '';
     } else {
       infoEl.textContent = 'Brak zapisanych linków do zdjęć.';
     }


### PR DESCRIPTION
## Summary
- remove the positive gallery info message so the text is hidden when images exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d93bb420d88322ba4c54576b8ee228