### PR TITLE
Center block dates modal

### DIFF
--- a/caretakerPanel.html
+++ b/caretakerPanel.html
@@ -100,7 +100,7 @@
 
   <div
     id="blockDatesModal"
-    class="fixed inset-0 z-50 hidden items-center justify-center bg-gray-900/50 px-4 py-6"
+    class="fixed inset-0 z-50 hidden flex items-center justify-center bg-gray-900/50 px-4 py-6"
     role="dialog"
     aria-modal="true"
     aria-labelledby="blockDatesModalTitle"


### PR DESCRIPTION
## Summary
- ensure the "Zablokuj terminy" modal wrapper uses flex layout so it centers when opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93c08fb248322982666c566e7bd17