### PR TITLE
Restore search card layout and adjust booking grid alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,14 @@
   </header>
 
   <!-- Layout -->
-  <main class="main-shell mx-auto my-8 grid max-w-6xl grid-cols-1 gap-8 p-6 sm:p-8 lg:grid-cols-3">
+  <main class="main-shell mx-auto my-8 grid max-w-6xl grid-cols-1 gap-8 p-6 sm:p-8 items-start lg:grid-cols-3">
     <!-- Lewa kolumna -->
-    <section class="lg:col-span-1">
+    <section class="lg:col-span-1 lg:self-start">
       <div id="sidebar"></div>
     </section>
 
     <!-- Prawa kolumna -->
-    <section class="lg:col-span-2">
+    <section class="lg:col-span-2 lg:self-start">
       <div id="main"></div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- restore the sidebar search card to its original static markup so it is no longer forced into a flex container or synced by JavaScript
- remove the layout-alignment helper hooks from the facilities module to keep the booking UI logic unchanged
- add Tailwind alignment classes to the booking grid so the sidebar and main content align neatly at the top on large screens

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9a1329ccc8322999d97654206fa26