### PR TITLE
Remove top margin from facility card

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,6 +85,10 @@
   border-top-width: 0;
 }
 
+.space-y-6 > #facilityCard {
+  margin-top: 0 !important;
+}
+
 .flow-space > .hidden + * {
   margin-top: 0 !important;
 }


### PR DESCRIPTION
## Summary
- add a CSS override so the facility card no longer receives the automatic 24px top spacing from the surrounding layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa02f74bc832297efd6c42de535cf