### PR TITLE
Add tabbed layout to caretaker facility editor

### DIFF
--- a/caretakerFacilityEdit.html
+++ b/caretakerFacilityEdit.html
@@ -23,7 +23,65 @@
   </header>
 
   <main class="max-w-4xl mx-auto p-4 space-y-5">
-    <section class="bg-white rounded-2xl shadow-md p-5 space-y-3">
+    <div class="bg-white rounded-2xl shadow-md p-3">
+      <nav class="flex flex-wrap gap-2" role="tablist" aria-label="Sekcje edycji świetlicy">
+        <button
+          type="button"
+          class="px-4 py-2 rounded-xl text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="tab-btn-meta"
+          data-tab-target="meta"
+          aria-controls="tab-panel-meta"
+        >
+          Dane podstawowe
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-xl text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="tab-btn-form"
+          data-tab-target="form"
+          aria-controls="tab-panel-form"
+        >
+          Formularz edycji
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-xl text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="tab-btn-instructions"
+          data-tab-target="instructions"
+          aria-controls="tab-panel-instructions"
+        >
+          Instrukcja od opiekuna
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-xl text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="tab-btn-amenities"
+          data-tab-target="amenities"
+          aria-controls="tab-panel-amenities"
+        >
+          Wyposażenie
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-xl text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="tab-btn-checklist"
+          data-tab-target="checklist"
+          aria-controls="tab-panel-checklist"
+        >
+          Lista kontrolna
+        </button>
+      </nav>
+      <div class="hidden">
+        <span class="bg-blue-600 text-white shadow bg-slate-100 text-slate-600 grid md:grid-cols-2 gap-4 space-y-3 text-sm text-gray-500"></span>
+      </div>
+    </div>
+
+    <section
+      id="tab-panel-meta"
+      class="bg-white rounded-2xl shadow-md p-5 space-y-3"
+      data-tab-panel="meta"
+      aria-labelledby="tab-btn-meta"
+    >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="space-y-1">
           <h2 class="text-lg font-semibold">Informacje o świetlicy</h2>
@@ -36,7 +94,13 @@
       </div>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-md p-5 space-y-4">
+    <section
+      id="tab-panel-form"
+      class="bg-white rounded-2xl shadow-md p-5 space-y-4"
+      data-tab-panel="form"
+      aria-labelledby="tab-btn-form"
+      hidden
+    >
       <div class="space-y-1">
         <h2 class="text-lg font-semibold">Edytuj dane świetlicy</h2>
         <p class="text-sm text-gray-500">Aktualizuj podstawowe informacje prezentowane mieszkańcom.</p>
@@ -216,7 +280,13 @@
       </form>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-md p-5 space-y-4">
+    <section
+      id="tab-panel-instructions"
+      class="bg-white rounded-2xl shadow-md p-5 space-y-4"
+      data-tab-panel="instructions"
+      aria-labelledby="tab-btn-instructions"
+      hidden
+    >
       <div>
         <label for="instructionsInput" class="block text-sm font-medium text-gray-700">Instrukcja od opiekuna</label>
         <textarea
@@ -234,7 +304,13 @@
       </div>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-md p-5 space-y-4">
+    <section
+      id="tab-panel-amenities"
+      class="bg-white rounded-2xl shadow-md p-5 space-y-4"
+      data-tab-panel="amenities"
+      aria-labelledby="tab-btn-amenities"
+      hidden
+    >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <h2 class="text-lg font-semibold">Wyposażenie świetlicy</h2>
@@ -256,7 +332,13 @@
       </div>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-md p-5 space-y-4">
+    <section
+      id="tab-panel-checklist"
+      class="bg-white rounded-2xl shadow-md p-5 space-y-4"
+      data-tab-panel="checklist"
+      aria-labelledby="tab-btn-checklist"
+      hidden
+    >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <h2 class="text-lg font-semibold">Lista kontrolna przekazania / zdania</h2>
@@ -281,7 +363,7 @@
           </button>
         </div>
       </div>
-      <div id="checklistContainer" class="space-y-3"></div>
+      <div id="checklistContainer" class="space-y-5"></div>
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <span id="checklistMessage" class="text-sm text-gray-500 min-h-[1.5rem]"></span>
         <span class="text-xs text-gray-400">Kolejność na liście odpowiada kolejności w raporcie LIVE.</span>


### PR DESCRIPTION
## Summary
- introduce a tabbed navigation for the caretaker facility editor to organize key sections
- adjust the checklist tab to display handover and return items side-by-side
- update client-side logic to manage tabs and render the checklist in separate columns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db80d774b083228b2582d6eb945912