### PR TITLE
Add standalone photo split layout tool

### DIFF
--- a/photoSplit.html
+++ b/photoSplit.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Generator wydruków 10x15</title>
+  <style>
+    :root {
+      --workspace-bg: #ffffff;
+      --column-gap: 8px;
+      --row-gap: 12px;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      background: #f2f2f2;
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 24px 16px 48px;
+      gap: 24px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.8rem;
+      text-align: center;
+    }
+
+    .controls {
+      width: min(960px, 100%);
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+      padding: 24px;
+      display: grid;
+      gap: 24px;
+    }
+
+    .controls-section {
+      display: grid;
+      gap: 12px;
+    }
+
+    .controls-section h2 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    .file-inputs {
+      display: grid;
+      gap: 12px;
+    }
+
+    .file-inputs label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-weight: 600;
+    }
+
+    .file-inputs input[type="file"] {
+      padding: 10px;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      background: #fafafa;
+    }
+
+    .sliders {
+      display: grid;
+      gap: 16px;
+    }
+
+    .slider-control {
+      display: grid;
+      gap: 8px;
+    }
+
+    .slider-control label {
+      font-weight: 600;
+    }
+
+    .slider-inputs {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .slider-inputs input[type="range"] {
+      flex: 1 1 260px;
+    }
+
+    .slider-inputs input[type="number"] {
+      width: 90px;
+      padding: 6px 8px;
+      border: 1px solid #bbb;
+      border-radius: 6px;
+    }
+
+    .background-picker {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .background-picker input[type="color"] {
+      width: 48px;
+      height: 32px;
+      border: none;
+      background: none;
+      cursor: pointer;
+    }
+
+    .workspace-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .workspace-label {
+      font-weight: 600;
+      color: #555;
+    }
+
+    .workspace {
+      width: 15cm;
+      height: 10cm;
+      background: var(--workspace-bg);
+      border-radius: 12px;
+      border: 1px solid rgba(0, 0, 0, 0.18);
+      box-shadow: 0 12px 36px rgba(0, 0, 0, 0.12);
+      overflow: hidden;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(2, 1fr);
+      column-gap: var(--column-gap);
+      row-gap: var(--row-gap);
+      padding: 14px;
+      box-sizing: border-box;
+      background-image: radial-gradient(circle at top left, rgba(255, 255, 255, 0.35), transparent 55%);
+      position: relative;
+    }
+
+    .workspace::before {
+      content: "";
+      position: absolute;
+      left: 14px;
+      right: 14px;
+      top: calc(50% - var(--row-gap) / 2);
+      border-top: 2px dotted rgba(0, 0, 0, 0.25);
+      pointer-events: none;
+    }
+
+    .image-half {
+      background-color: rgba(0, 0, 0, 0.08);
+      background-size: 200% auto;
+      background-repeat: no-repeat;
+      background-position: center;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: rgba(0, 0, 0, 0.4);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-size: 0.85rem;
+    }
+
+    .image-half.filled {
+      color: transparent;
+    }
+
+    @media (max-width: 960px) {
+      .workspace {
+        width: min(15cm, 100%);
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>Przygotuj wydruk 10×15 cm</h1>
+
+  <div class="controls">
+    <section class="controls-section">
+      <h2>Wgraj zdjęcia</h2>
+      <div class="file-inputs">
+        <label for="photo1">
+          Zdjęcie 1
+          <input type="file" id="photo1" accept="image/*" />
+        </label>
+        <label for="photo2">
+          Zdjęcie 2
+          <input type="file" id="photo2" accept="image/*" />
+        </label>
+      </div>
+    </section>
+
+    <section class="controls-section">
+      <h2>Ustaw odstępy</h2>
+      <div class="sliders">
+        <div class="slider-control">
+          <label for="columnGapRange">Odstęp między kolumnami (mm)</label>
+          <div class="slider-inputs">
+            <input type="range" id="columnGapRange" min="0" max="30" value="8" step="1" />
+            <input type="number" id="columnGapNumber" min="0" max="30" value="8" step="1" />
+          </div>
+        </div>
+        <div class="slider-control">
+          <label for="rowGapRange">Odstęp między wierszami (mm)</label>
+          <div class="slider-inputs">
+            <input type="range" id="rowGapRange" min="0" max="30" value="12" step="1" />
+            <input type="number" id="rowGapNumber" min="0" max="30" value="12" step="1" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="controls-section">
+      <h2>Tło obszaru roboczego</h2>
+      <div class="background-picker">
+        <label for="backgroundColor">Wybierz kolor:</label>
+        <input type="color" id="backgroundColor" value="#ffffff" />
+      </div>
+    </section>
+  </div>
+
+  <div class="workspace-wrapper">
+    <span class="workspace-label">Obszar roboczy 10×15 cm</span>
+    <div class="workspace" id="workspace">
+      <div class="image-half" id="photo1-left">Zdjęcie 1</div>
+      <div class="image-half" id="photo1-right">Zdjęcie 1</div>
+      <div class="image-half" id="photo2-left">Zdjęcie 2</div>
+      <div class="image-half" id="photo2-right">Zdjęcie 2</div>
+    </div>
+  </div>
+
+  <script>
+    const mmToPx = (mm) => mm * (96 / 25.4);
+
+    const photoInputs = [
+      { input: document.getElementById('photo1'), left: document.getElementById('photo1-left'), right: document.getElementById('photo1-right') },
+      { input: document.getElementById('photo2'), left: document.getElementById('photo2-left'), right: document.getElementById('photo2-right') }
+    ];
+
+    photoInputs.forEach(({ input, left, right }) => {
+      input.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        if (!file) {
+          left.style.backgroundImage = '';
+          right.style.backgroundImage = '';
+          left.classList.remove('filled');
+          right.classList.remove('filled');
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = () => {
+          const dataUrl = reader.result;
+          left.style.backgroundImage = `url(${dataUrl})`;
+          right.style.backgroundImage = `url(${dataUrl})`;
+          left.style.backgroundPosition = 'left center';
+          right.style.backgroundPosition = 'right center';
+          left.classList.add('filled');
+          right.classList.add('filled');
+        };
+        reader.readAsDataURL(file);
+      });
+    });
+
+    const workspace = document.getElementById('workspace');
+
+    const columnGapRange = document.getElementById('columnGapRange');
+    const columnGapNumber = document.getElementById('columnGapNumber');
+    const rowGapRange = document.getElementById('rowGapRange');
+    const rowGapNumber = document.getElementById('rowGapNumber');
+
+    const syncGapControls = (rangeInput, numberInput, cssVariable) => {
+      const updateGap = (value) => {
+        const numericValue = Math.max(Number(rangeInput.min), Math.min(Number(rangeInput.max), Number(value)));
+        rangeInput.value = numericValue;
+        numberInput.value = numericValue;
+        workspace.style.setProperty(cssVariable, `${mmToPx(numericValue)}px`);
+      };
+
+      rangeInput.addEventListener('input', (e) => updateGap(e.target.value));
+      numberInput.addEventListener('input', (e) => updateGap(e.target.value));
+
+      updateGap(rangeInput.value);
+    };
+
+    syncGapControls(columnGapRange, columnGapNumber, '--column-gap');
+    syncGapControls(rowGapRange, rowGapNumber, '--row-gap');
+
+    const backgroundColorPicker = document.getElementById('backgroundColor');
+    backgroundColorPicker.addEventListener('input', (event) => {
+      const color = event.target.value;
+      document.documentElement.style.setProperty('--workspace-bg', color);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `photoSplit.html` page that prepares two uploaded photos split vertically inside a 10×15 cm workspace
- provide synchronized range and numeric inputs to adjust the spacing between columns and rows in millimeters
- allow choosing a custom background color for the printable workspace

## Testing
- Not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68db998c932483229ab01db9ef4ae36b