### PR TITLE
Support labeled booking extra placeholders

### DIFF
--- a/designTemplate.html
+++ b/designTemplate.html
@@ -25,7 +25,10 @@
     <div class="max-w-6xl mx-auto flex items-center justify-between">
       <div>
         <h1 class="text-xl font-bold">Design Template</h1>
-        <p class="text-xs text-gray-500">Placeholdery: <code>{{booking.*}}</code>, <code>{{facility.*}}</code>, <code>{{date booking.start_time}}</code>, <code>{{time booking.start_time}}</code></p>
+        <p class="text-xs text-gray-500">
+          Placeholdery: <code>{{booking.*}}</code>, <code>{{facility.*}}</code>, <code>{{date booking.start_time}}</code>, <code>{{time booking.start_time}}</code>.
+          Własne pola formularza: <code>{{booking.extra.nazwa_pola|Etykieta (opcjonalnie)}}</code> – etykieta pojawia się tylko w formularzu, a w szablonie podstawiana jest wartość z klucza <code>nazwa_pola</code>.
+        </p>
       </div>
       <a href="./index.html" class="text-sm text-blue-700 underline">← powrót do aplikacji</a>
     </div>


### PR DESCRIPTION
## Summary
- allow document templates to use optional labels on booking.extra placeholders while keeping substitution keyed by the field name
- surface the optional labels in the live field table and deduplicate inputs by key
- document the new placeholder syntax for template authors in the designer header

## Testing
- Manual verification of labeled placeholder parsing and substitution

------
https://chatgpt.com/codex/tasks/task_e_68de8a357aa48322ad2a40658868aa77